### PR TITLE
K8s client and apply manifests

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,14 +27,16 @@ import (
 )
 
 var (
-	path      string
-	image     string
-	name      string
-	namespace string
-	type_     string
-	template  string
-	gpus      int
-	dryRun    bool
+	path            string
+	image           string
+	name            string
+	namespace       string
+	type_           string
+	template        string
+	gpus            int
+	dryRun          bool
+	createNamespace bool
+	noUploadFolder  bool
 )
 
 const defaultImage = "ghcr.io/silogen/rocm-ray:v0.4"
@@ -51,14 +53,16 @@ func main() {
 		Run: func(cmd *cobra.Command, args []string) {
 
 			var workloadArgs templates.WorkloadArgs = templates.WorkloadArgs{
-				Path:         path,
-				Image:        image,
-				Name:         name,
-				Namespace:    namespace,
-				TemplatePath: template,
-				Type:         type_,
-				GPUs:         gpus,
-				DryRun:       dryRun,
+				Path:            path,
+				Image:           image,
+				Name:            name,
+				Namespace:       namespace,
+				TemplatePath:    template,
+				Type:            type_,
+				GPUs:            gpus,
+				DryRun:          dryRun,
+				CreateNamespace: createNamespace,
+				NoUploadFolder:  noUploadFolder,
 			}
 
 			if err := submit.Submit(workloadArgs); err != nil {
@@ -78,6 +82,8 @@ func main() {
 	submitCmd.Flags().StringVarP(&image, "image", "i", defaultImage, "Container image to use. Defaults to ghcr.io/silogen/rocm-ray:vx.x")
 	submitCmd.Flags().StringVarP(&name, "name", "n", "", "Kubenetes name to use for the workflow")
 	submitCmd.Flags().StringVarP(&namespace, "namespace", "", "aiwo", "Kubenetes namespace to use. Defaults to `aiwo`")
+	submitCmd.Flags().BoolVarP(&createNamespace, "create-namespace", "", false, "Create namespace if it does not exist")
+	submitCmd.Flags().BoolVarP(&noUploadFolder, "no-upload-folder", "", false, "Don't upload path folder contents as a config map")
 	submitCmd.Flags().StringVarP(&template, "template", "", "", "Path to a custom template to use for the workload. If not provided, a default template will be used")
 	submitCmd.Flags().StringVarP(&type_, "type", "t", "job", "Workload type, one of [rayjob, rayservice]")
 	submitCmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "Print the generated workload manifest without submitting it")

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -1,0 +1,32 @@
+package k8s
+
+import (
+	"flag"
+	"fmt"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/tools/clientcmd"
+	"k8s.io/client-go/util/homedir"
+	"path/filepath"
+)
+
+func InitializeClient() (dynamic.Interface, error) {
+	var kubeconfig *string
+	if home := homedir.HomeDir(); home != "" {
+		kubeconfig = flag.String("kubeconfig", filepath.Join(home, ".kube", "config"), "(optional) absolute path to the kubeconfig file")
+	} else {
+		kubeconfig = flag.String("kubeconfig", "", "absolute path to the kubeconfig file")
+	}
+	flag.Parse()
+
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
+	if err != nil {
+		return nil, fmt.Errorf("failed to build kubeconfig: %v", err)
+	}
+
+	dynamicClient, err := dynamic.NewForConfig(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create dynamic client: %v", err)
+	}
+
+	return dynamicClient, nil
+}

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -3,60 +3,23 @@ package k8s
 import (
 	"bytes"
 	"fmt"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"os"
 	"path/filepath"
 	"slices"
-	"strings"
-
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/sirupsen/logrus"
-
-	appsv1 "k8s.io/api/apps/v1"
-	batchv1 "k8s.io/api/batch/v1"
-	corev1 "k8s.io/api/core/v1"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-
-	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 )
-
-func CreateNamespace(namespace string) *v1.Namespace {
-	return &v1.Namespace{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "Namespace",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name: namespace,
-		},
-	}
-}
 
 func isBinaryFile(content []byte) bool {
 	return bytes.Contains(content, []byte{0})
 }
 
 // Generate ConfigMap from a directory
-func GenerateConfigMapFromDir(dir string, configmap_name string, namespace string, skipFiles []string) (v1.ConfigMap, error) {
+func GenerateConfigMapFromDir(dir string, name string, namespace string, skipFiles []string) (*unstructured.Unstructured, error) {
 	files, err := os.ReadDir(dir)
 
-	configMap := v1.ConfigMap{
-		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      configmap_name,
-			Namespace: namespace,
-		},
-		Data: make(map[string]string),
-	}
-
 	if err != nil {
-		return configMap, fmt.Errorf("failed to read directory: %w", err)
+		return nil, fmt.Errorf("failed to read directory: %w", err)
 	}
 
 	data := make(map[string]string)
@@ -73,7 +36,7 @@ func GenerateConfigMapFromDir(dir string, configmap_name string, namespace strin
 		filePath := filepath.Join(dir, file.Name())
 		content, err := os.ReadFile(filePath)
 		if err != nil {
-			return configMap, fmt.Errorf("failed to read file %s: %w", filePath, err)
+			return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
 		}
 
 		// Skip binary files
@@ -84,39 +47,17 @@ func GenerateConfigMapFromDir(dir string, configmap_name string, namespace strin
 		data[file.Name()] = string(content)
 	}
 
-	configMap.Data = data
-
-	return configMap, nil
-}
-
-func DecodeYAMLToObjects(yamlData string) ([]runtime.Object, error) {
-	// Create a new scheme and add all known types to it
-	scheme := runtime.NewScheme()
-	_ = corev1.AddToScheme(scheme)
-	_ = appsv1.AddToScheme(scheme)
-	_ = rayv1.AddToScheme(scheme)
-	_ = batchv1.AddToScheme(scheme)
-
-	// Create a YAML decoder
-	decoder := serializer.NewCodecFactory(scheme).UniversalDeserializer()
-
-	// Split the YAML into individual documents
-	documents := strings.Split(yamlData, "---")
-
-	var objects []runtime.Object
-	for _, doc := range documents {
-		if strings.TrimSpace(doc) == "" {
-			continue
-		}
-
-		// Decode each document into a runtime.Object
-		obj, _, err := decoder.Decode([]byte(doc), nil, nil)
-		if err != nil {
-			return nil, fmt.Errorf("failed to decode YAML: %w", err)
-		}
-
-		objects = append(objects, obj)
+	configMap := &unstructured.Unstructured{
+		Object: map[string]interface{}{
+			"apiVersion": "v1",
+			"kind":       "ConfigMap",
+			"metadata": map[string]interface{}{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"data": data,
+		},
 	}
 
-	return objects, nil
+	return configMap, nil
 }

--- a/pkg/submit/submit.go
+++ b/pkg/submit/submit.go
@@ -17,7 +17,16 @@
 package submit
 
 import (
+	"context"
 	"fmt"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	k8syaml "k8s.io/apimachinery/pkg/runtime/serializer/yaml"
+	"k8s.io/client-go/dynamic"
+	"sigs.k8s.io/yaml"
+
 	"os"
 	"os/user"
 	"path/filepath"
@@ -28,8 +37,6 @@ import (
 	"github.com/silogen/ai-workload-orchestrator/pkg/k8s"
 	"github.com/silogen/ai-workload-orchestrator/pkg/templates"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/cli-runtime/pkg/printers"
 )
 
 // TODO clarify naming?
@@ -64,31 +71,73 @@ func Submit(args templates.WorkloadArgs) error {
 		return fmt.Errorf("live run is not supported yet, please use --dry-run")
 	}
 
-	if err := templates.ValidateWorkloadArgs(args); err != nil {
-		return err
-	}
+	loader, err := initializeLoader(args)
 
 	args.Name = setWorkloadName(args.Name, args.Path)
 
-	logrus.Infof("Submitting workload '%s' from path: %s", args.Name, args.Path)
-
-	if args.Type == "" {
-		args.Type = "job"
-
-	}
-
-	loader := templates.GetWorkloadLoader(args.Type)
-
-	// Load workload
-	if err := loader.Load(args.Path); err != nil {
-		return fmt.Errorf("failed to load workload: %w", err)
-	}
-
-	// Generate ConfigMap
-	configMap, err := k8s.GenerateConfigMapFromDir(args.Path, args.Name, args.Namespace, loader.IgnoreFiles())
 	if err != nil {
-		return fmt.Errorf("failed to generate ConfigMap: %w", err)
+		return err
 	}
+
+	var c dynamic.Interface
+
+	if !args.DryRun {
+		logrus.Infof("Initializing Kubernetes client")
+		c, err = k8s.InitializeClient()
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to initialize k8s client: %v", err)
+	}
+
+	var resources []*unstructured.Unstructured
+
+	// Namespace TODO refactor to own method
+	if args.CreateNamespace {
+		namespace := unstructured.Unstructured{
+			Object: map[string]interface{}{
+				"apiVersion": "v1",
+				"kind":       "Namespace",
+				"metadata": map[string]interface{}{
+					"name": args.Namespace,
+				},
+			},
+		}
+		if args.DryRun {
+			logrus.Info("Including namespace definition, but not checking existence due to dry-run mode")
+			resources = append(resources, &namespace)
+		} else {
+			logrus.Infof("checking namespace %s", args.Namespace)
+			gvr := schema.GroupVersionResource{
+				Group:    "",
+				Version:  "v1",
+				Resource: "namespaces",
+			}
+			_, err := c.Resource(gvr).Get(context.TODO(), args.Namespace, metav1.GetOptions{})
+			if err == nil {
+				// Namespace already exists
+				logrus.Infof("namespace %s already exists", args.Namespace)
+				return nil
+			} else if !apierrors.IsNotFound(err) {
+				return fmt.Errorf("failed to check if namespace exists: %v", err)
+			} else {
+				resources = append(resources, &namespace)
+			}
+		}
+	}
+
+	// Config map
+	if args.NoUploadFolder {
+		logrus.Info("Skipping upload folder")
+	} else {
+		configMap, err := k8s.GenerateConfigMapFromDir(args.Path, args.Name, args.Namespace, loader.IgnoreFiles())
+		if err != nil {
+			return fmt.Errorf("failed to generate ConfigMap: %w", err)
+		}
+		resources = append(resources, configMap)
+	}
+
+	// Workload template TODO refactor to own method
 
 	var workloadTemplate []byte
 
@@ -117,42 +166,133 @@ func Submit(args templates.WorkloadArgs) error {
 		return fmt.Errorf("failed to parse template: %w", err)
 	}
 
-	// Render the template
 	var renderedYAML strings.Builder
 	err = parsedTemplate.Execute(&renderedYAML, templateContext)
+
+	// Render the template
 	if err != nil {
 		return fmt.Errorf("failed to render template: %w", err)
 	}
 
-	// Marshal the template into a Kubernetes object
-	templatedManifests, err := k8s.DecodeYAMLToObjects(renderedYAML.String())
+	logrus.Infof("Parsing workload template")
 
-	if err != nil {
-		return fmt.Errorf("failed to decode workload manifest YAML: %w", err)
+	decoder := k8syaml.NewDecodingSerializer(unstructured.UnstructuredJSONScheme)
+	manifests := strings.Split(renderedYAML.String(), "---")
+
+	for _, manifest := range manifests {
+
+		manifest = strings.TrimSpace(manifest)
+		if manifest == "" {
+			continue
+		}
+
+		// Decode the manifest into an unstructured object
+		obj := &unstructured.Unstructured{}
+		_, gvk, err := decoder.Decode([]byte(manifest), nil, obj)
+
+		if err != nil {
+			return fmt.Errorf("failed to decode YAML manifest: %v", err)
+		}
+
+		_ = gvk
+
+		resources = append(resources, obj)
 	}
-
-	// TODO only create namespace if it doesn't exist (we don't want to delete namespaces when deleting resources)
-	// namespace := k8s.CreateNamespace(args.Namespace)
-
-	workloadManifests := append([]runtime.Object{&configMap}, templatedManifests...)
 
 	if args.DryRun {
 		logrus.Info("Dry-run. Printing generated workload to console")
-		yamlPrinter := printers.YAMLPrinter{}
-
-		printedYaml := strings.Builder{}
-		for _, obj := range workloadManifests {
-			err = yamlPrinter.PrintObj(obj, &printedYaml)
-			if err != nil {
-				logrus.Errorf("failed to marshal object: %v", err)
-			} else {
-				fmt.Println(string(printedYaml.String()))
-			}
-			printedYaml.Reset()
+		printResources(resources)
+	} else {
+		err = applyResources(resources, c)
+		if err != nil {
+			return fmt.Errorf("failed to apply resources: %w", err)
 		}
-		return nil
+		logrus.Info("Workload submitted successfully.")
 	}
 
-	logrus.Info("Workload submitted successfully.")
+	return nil
+}
+
+func initializeLoader(args templates.WorkloadArgs) (templates.WorkloadLoader, error) {
+	if err := templates.ValidateWorkloadArgs(args); err != nil {
+		return nil, err
+	}
+
+	args.Name = setWorkloadName(args.Name, args.Path)
+
+	logrus.Infof("Submitting workload '%s' from path: %s", args.Name, args.Path)
+
+	if args.Type == "" {
+		args.Type = "job"
+	}
+
+	loader := templates.GetWorkloadLoader(args.Type)
+
+	if err := loader.Load(args.Path); err != nil {
+		return nil, fmt.Errorf("failed to load workload: %w", err)
+	}
+
+	return loader, nil
+}
+
+func printResources(resources []*unstructured.Unstructured) {
+	for _, resource := range resources {
+		logrus.Infof("%s: %s", resource.GetKind(), resource.GetName())
+		data := resource.UnstructuredContent()
+
+		// Marshal the map into YAML
+		yamlBytes, err := yaml.Marshal(data)
+		if err != nil {
+			logrus.Errorf("failed to convert unstructured object to YAML: %v", err)
+		}
+		fmt.Print(string(yamlBytes))
+		fmt.Println("---")
+	}
+}
+
+func applyResources(resources []*unstructured.Unstructured, c dynamic.Interface) error {
+	//return fmt.Errorf("applying resources is not implemented yet")
+
+	for _, resource := range resources {
+		gvk := resource.GroupVersionKind()
+
+		// Derive the GVR from the GVK
+		gvr := schema.GroupVersionResource{
+			Group:    gvk.Group,
+			Version:  gvk.Version,
+			Resource: strings.ToLower(gvk.Kind) + "s", // Pluralize the kind
+		}
+
+		// Determine the namespace
+		namespace := resource.GetNamespace()
+		if namespace == "" {
+			namespace = "default"
+		}
+
+		// Try to create the resource
+		_, err := c.Resource(gvr).Namespace(namespace).Create(context.TODO(), resource, metav1.CreateOptions{})
+		if err == nil {
+			logrus.Infof("Resource %s/%s created successfully", namespace, resource.GetName())
+			continue
+		}
+
+		if !apierrors.IsAlreadyExists(err) {
+			return fmt.Errorf("failed to apply resource %s/%s: %v", namespace, resource.GetName(), err)
+		}
+
+		// Resource already exists, update it
+		existing, err := c.Resource(gvr).Namespace(namespace).Get(context.TODO(), resource.GetName(), metav1.GetOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to get existing resource %s/%s: %v", namespace, resource.GetName(), err)
+		}
+
+		resource.SetResourceVersion(existing.GetResourceVersion())
+		_, err = c.Resource(gvr).Namespace(namespace).Update(context.TODO(), resource, metav1.UpdateOptions{})
+		if err != nil {
+			return fmt.Errorf("failed to update resource %s/%s: %v", namespace, resource.GetName(), err)
+		}
+
+		logrus.Infof("Resource %s/%s updated successfully", namespace, resource.GetName())
+	}
 	return nil
 }

--- a/pkg/templates/base.go
+++ b/pkg/templates/base.go
@@ -7,14 +7,16 @@ import (
 
 // WorkloadArgs is a struct that holds the high-level arguments used for all workloads
 type WorkloadArgs struct {
-	Path         string
-	Image        string
-	Name         string
-	Namespace    string
-	Type         string
-	GPUs         int
-	TemplatePath string
-	DryRun       bool
+	Path            string
+	Image           string
+	Name            string
+	Namespace       string
+	Type            string
+	GPUs            int
+	TemplatePath    string
+	DryRun          bool
+	CreateNamespace bool
+	NoUploadFolder  bool
 }
 
 func ValidateWorkloadArgs(args WorkloadArgs) error {
@@ -25,12 +27,12 @@ func ValidateWorkloadArgs(args WorkloadArgs) error {
 }
 
 type WorkloadLoader interface {
-	// Loads a workload from a path
+	// Load loads a workload from a path
 	Load(path string) error
 
-	// Returns the default teplate for the workloader
+	// DefaultTemplate returns the default template for the workloader
 	DefaultTemplate() []byte
 
-	// Lists the files that should be ignored in the ConfigMap
+	// IgnoreFiles lists the files that should be ignored in the ConfigMap
 	IgnoreFiles() []string
 }


### PR DESCRIPTION
* Moved from handling structured k8s objects to unstructured objects in order to not have to hard-code any resource kind that may appear in the templates
* Moved namespace and configmaps to unstructured objects as well to simplify handling
* Added helper for initializing the dynamic k8s client
* Added CLI flags to skip creating configmap and to create namespace

TODO
- [ ] Test actually applying