### PR TITLE
Add initial implementation for handling ImagePullSecrets

### DIFF
--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -129,7 +129,7 @@ func ReadEnvFile(filePath string) ([]corev1.EnvVar, []SecretVolume, []corev1.Loc
 
 	var envVars []corev1.EnvVar
 	var secretVolumes []SecretVolume
-	var imagePullSecrets []corev1.LocalObjectReference //`json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
+	var imagePullSecrets []corev1.LocalObjectReference // This is the type in K8s for ImagePullSecrets
 
 	for _, input := range envFile.EnvVars {
 		if input.Value != "" {

--- a/pkg/submit/submit.go
+++ b/pkg/submit/submit.go
@@ -59,7 +59,7 @@ func Submit(args utils.WorkloadArgs) error {
 
 	var envVars []corev1.EnvVar
 	var secretVolumes []k8s.SecretVolume
-	var imagePullSecrets []corev1.LocalObjectReference //`json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`
+	var imagePullSecrets []corev1.LocalObjectReference // This is the type in K8s for ImagePullSecrets
 	envFilePath := filepath.Join(args.Path, utils.ENV_FILENAME)
 	if _, err := os.Stat(envFilePath); err == nil {
 		logrus.Infof("Found env file at %s, parsing environment variables and secret volumes", envFilePath)
@@ -231,7 +231,7 @@ func processWorkloadTemplate(
 	resources *[]*unstructured.Unstructured,
 	envVars []corev1.EnvVar,
 	secretVolumes []k8s.SecretVolume,
-	imagePullSecrets []corev1.LocalObjectReference, //`json:"imagePullSecrets,omitempty" patchStrategy:"merge" patchMergeKey:"name" protobuf:"bytes,15,rep,name=imagePullSecrets"`,
+	imagePullSecrets []corev1.LocalObjectReference,
 ) error {
 	var workloadTemplate []byte
 	var err error

--- a/pkg/templates/cleanup.go
+++ b/pkg/templates/cleanup.go
@@ -3,7 +3,7 @@ package templates
 import (
 	"context"
 	"fmt"
-	"github.com/silogen/ai-workload-orchestrator/pkg/k8s"
+	"github.com/silogen/kaiwo/pkg/k8s"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/templates/jobs/job.yaml.tmpl
+++ b/pkg/templates/jobs/job.yaml.tmpl
@@ -10,6 +10,12 @@ spec:
   template:
     spec:
       restartPolicy: "Never"
+      {{- if .ImagePullSecrets }}
+      {{- range .ImagePullSecrets }}
+      imagePullSecrets:
+        - name: {{ .Name }} 
+      {{- end }}
+      {{- end }}
       containers:
       - name: {{ .Base.Name }}
         image: {{ .Base.Image }}

--- a/pkg/templates/ray/rayjob.yaml.tmpl
+++ b/pkg/templates/ray/rayjob.yaml.tmpl
@@ -17,6 +17,12 @@ spec:
       rayStartParams: {}
       template:
         spec:
+          {{- if .ImagePullSecrets }}
+          {{- range .ImagePullSecrets }}
+          imagePullSecrets:
+            - name: {{ .Name }} 
+          {{- end }}
+          {{- end }}
           containers:
             - name: ray-head
               image: {{ .Base.Image }}
@@ -93,6 +99,12 @@ spec:
         rayStartParams: {}
         template:
           spec:
+            {{- if .ImagePullSecrets }}
+            {{- range .ImagePullSecrets }}
+            imagePullSecrets:
+              - name: {{ .Name }} 
+            {{- end }}
+            {{- end }}
             containers:
               - name: ray-worker
                 image: {{ .Base.Image }}


### PR DESCRIPTION
I hacked this together to get some familiarity with the kaiwo codebase and because I needed it to use images from Silogen's Google registry. I feel that this is better seen as a starting point for consideration rather than to merge as is, thus Draft.

Added a way to add ImagePullSecrets in the env file. This is currently under the EnvVars listing, which is not ideal since this is not an environment variable. Perhaps some flexible way to provide arbitrary values to the templating engine could be a good avenue to specify this.

Another way to handle imagepullsecrets would be to do so automatically via serviceaccounts: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

Yet another way would be a commandline arg instead of an env var.

MISC:
- Ran gofmt on the files I edited, it made some misc changes.
- Needed to change one pkg/templates/cleanup.go import reference from ai-workload-orchestrator to kaiwo to get this to compile on my machine.