### PR TITLE
Update import in cleanup.go

### DIFF
--- a/pkg/templates/cleanup.go
+++ b/pkg/templates/cleanup.go
@@ -3,7 +3,7 @@ package templates
 import (
 	"context"
 	"fmt"
-	"github.com/silogen/ai-workload-orchestrator/pkg/k8s"
+	"github.com/silogen/kaiwo/pkg/k8s"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
Simple fix to allow running `build_all_arch.sh`.