### PR TITLE
Longer hardcoded ttlSecondsAfterFinished

### DIFF
--- a/pkg/workloads/jobs/job.yaml.tmpl
+++ b/pkg/workloads/jobs/job.yaml.tmpl
@@ -7,7 +7,7 @@ metadata:
     kueue.x-k8s.io/queue-name: {{ .WorkloadMeta.Queue }}
     kaiwo-cli/username: {{ .Meta.User }}
 spec:
-  ttlSecondsAfterFinished: 60 
+  ttlSecondsAfterFinished: 3600
   template:
     spec:
       restartPolicy: "Never"


### PR DESCRIPTION
The ttlSecondsAfterFinished pass-through was removed, I think it was because other resources like configmaps would be left dangling after the job was removed. As a temporary setting, this was turned into a hardcoded ttlSecondsAfterFinished value of 1 minute, which is very short, I have trouble reading through logs to see what happened in that time. I think an hour is a better temporary hardcoded value, if we want one. Or should this be removed completely?