### PR TITLE
Don't hardcode defaultimage in CLI, set default in template

### DIFF
--- a/pkg/cmd/apply/utils.go
+++ b/pkg/cmd/apply/utils.go
@@ -57,7 +57,6 @@ func GetExecFlags() workloads.ExecFlags {
 // Kubernetes meta flags
 
 const defaultNamespace = "kaiwo"
-const defaultImage = "ghcr.io/silogen/rocm-ray:v0.4"
 
 var (
 	name            string
@@ -71,7 +70,7 @@ var (
 func AddMetaFlags(cmd *cobra.Command) {
 	cmd.Flags().StringVarP(&name, "name", "", "", "Name of the workload")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", defaultNamespace, "Namespace of the workload")
-	cmd.Flags().StringVarP(&image, "image", "i", defaultImage, "The image to use for the workload")
+	cmd.Flags().StringVarP(&image, "image", "i", "", "The image to use for the workload")
 	cmd.Flags().StringVarP(&imagePullSecret, "imagepullsecret", "", "", "ImagePullSecret name for job/deployment if private registry")
 	cmd.Flags().StringVarP(&version, "version", "", "", "Optional version for job/deployment")
 }

--- a/pkg/workloads/deployments/deployment.yaml.tmpl
+++ b/pkg/workloads/deployments/deployment.yaml.tmpl
@@ -22,7 +22,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Meta.Name }}
-        image: {{ .Meta.Image }}
+        image: {{ default "ghcr.io/silogen/rocm-ray:v0.4" .Meta.Image }}
         imagePullPolicy: Always
         {{- if .Workload.Entrypoint }}
         command: 

--- a/pkg/workloads/jobs/job.yaml.tmpl
+++ b/pkg/workloads/jobs/job.yaml.tmpl
@@ -17,7 +17,7 @@ spec:
       {{- end }}
       containers:
       - name: {{ .Meta.Name }}
-        image: {{ .Meta.Image }}
+        image: {{ default "ghcr.io/silogen/rocm-ray:v0.4" .Meta.Image }}
         imagePullPolicy: Always
         {{- if .Workload.Entrypoint }}
         command: 

--- a/pkg/workloads/ray/deployment.yaml.tmpl
+++ b/pkg/workloads/ray/deployment.yaml.tmpl
@@ -21,7 +21,7 @@ spec:
           {{- end }}
           containers:
             - name: ray-head
-              image: {{ .Meta.Image }}
+              image: {{ default "ghcr.io/silogen/rocm-ray:v0.4" .Meta.Image }}
               env:
               {{- if .Meta.EnvVars }}
               {{- range .Meta.EnvVars }}

--- a/pkg/workloads/ray/job.yaml.tmpl
+++ b/pkg/workloads/ray/job.yaml.tmpl
@@ -23,7 +23,7 @@ spec:
           {{- end }}
           containers:
             - name: ray-head
-              image: {{ .Meta.Image }}
+              image: {{ default "ghcr.io/silogen/rocm-ray:v0.4" .Meta.Image }}
               imagePullPolicy: Always
               env:
               {{- if .Meta.EnvVars }}
@@ -103,7 +103,7 @@ spec:
             {{- end }}
             containers:
               - name: ray-worker
-                image: {{ .Meta.Image }}
+                image: {{ default "ghcr.io/silogen/rocm-ray:v0.4" .Meta.Image }}
                 imagePullPolicy: Always
                 env:
                 {{- if .Meta.EnvVars }}


### PR DESCRIPTION
One key default that a template writer wants to set is the default image. I've been wanting to do this, so I implemented what @salexo proposed offline.

Closes issue #39 .