### PR TITLE
make workload name shorter

### DIFF
--- a/pkg/cmd/apply/run.go
+++ b/pkg/cmd/apply/run.go
@@ -198,7 +198,7 @@ func makeWorkloadName(path string, image string, version string, currentUser str
 		version = sanitizeStringForKubernetes(version)
 		separatorCount = 2 // Include one more "-" for the version
 	}
-	maxAppendixLength := 63 - len(currentUser) - len(version) - separatorCount
+	maxAppendixLength := 45 - len(currentUser) - len(version) - separatorCount
 
 	// Truncate appendix if necessary
 	if len(appendix) > maxAppendixLength {


### PR DESCRIPTION
# Description

The PR fixes a naming bug that stops RayClusters from starting


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [x] Existing workload examples run after my changes (if applicable)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes