### PR TITLE
add an overlay-path flag to combine files from two folders

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -17,7 +17,7 @@ Please delete options that are not relevant.
 # Checklist:
 
 - [ ] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
-- [ ] Existing workload examples run after my changes (if applicable)
+- [ ] Existing workload examples run to completion after my changes (if applicable)
 - [ ] I have performed a self-review of my code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [ ] I have made corresponding changes to the documentation

--- a/.github/workflows/compile-release.yaml
+++ b/.github/workflows/compile-release.yaml
@@ -1,0 +1,46 @@
+name: compile-release
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+
+      - name: Extract version from tag
+        shell: bash
+        run: |
+          echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
+          echo "Using version: ${VERSION}"
+
+      - name: Run build script
+        shell: bash
+        run: |
+          set -e
+          chmod +x build_cli_all_arch.sh
+          ./build_cli_all_arch.sh "$VERSION"
+
+      - name: Compress workloads
+        shell: bash
+        run: |
+          zip -r workloads.zip ./workloads
+
+      - name: Create draft release and upload assets
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            builds/*
+            workloads.zip
+          token: '${{ secrets.GITHUB_TOKEN }}'
+          draft: true
+          prerelease: true

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,8 +6,8 @@
 	    "type": "go",
 	    "request": "launch",
 	    "mode": "debug",
-	    "program": "${workspaceFolder}",
-	    "args": ["submit", "-p", "workloads/training/LLMs/lora-supervised-finetuning/lora-sft-zero3-single-multinode", "--ray", "-g", "4", "--dry-run"],
+	    "program": "${workspaceFolder}/cmd/cli/main.go",
+	    "args": ["submit", "-p", "${workspaceFolder}/workloads/training/LLMs/lora-supervised-finetuning/lora-sft-zero3-single-multinode", "--ray", "-g", "4", "--dry-run", "--storage=100Gi,longhorn"],
 	    "env": {
 	      "GO111MODULE": "on"
 	    },
@@ -18,8 +18,8 @@
 		"type": "go",
 		"request": "launch",
 		"mode": "debug",
-		"program": "${workspaceFolder}",
-		"args": ["serve", "-p", "workloads/inference/LLMs/online-inference/vllm-online-single-multinode", "--ray", "--replicas", "1", "--gpus-per-replica", "4", "--dry-run"],
+		"program": "${workspaceFolder}/cmd/cli/main.go",
+		"args": ["serve", "-p", "${workspaceFolder}/workloads/inference/LLMs/online-inference/vllm-online-single-multinode", "--ray", "--replicas", "1", "--gpus-per-replica", "4", "--dry-run"],
 		"env": {
 		  "GO111MODULE": "on"
 		},
@@ -30,8 +30,8 @@
 		"type": "go",
 		"request": "launch",
 		"mode": "debug",
-		"program": "${workspaceFolder}",
-		"args": ["submit", "-p", "workloads/training/LLMs/bert/hf-accelerate-bert", "-g", "4", "--dry-run"],
+		"program": "${workspaceFolder}/cmd/cli/main.go",
+		"args": ["submit", "-p", "${workspaceFolder}/workloads/training/LLMs/bert/hf-accelerate-bert", "-g", "4", "--dry-run"],
 		"env": {
 		  "GO111MODULE": "on"
 		},
@@ -42,7 +42,7 @@
 		"type": "go",
 		"request": "launch",
 		"mode": "debug",
-		"program": "${workspaceFolder}",
+		"program": "${workspaceFolder}/cmd/cli/main.go",
 		"args": ["submit", "-i", "ghcr.io/silogen/rocm-ray:v0.4", "-g", "4"],
 		"env": {
 		  "GO111MODULE": "on"
@@ -54,8 +54,8 @@
 		"type": "go",
 		"request": "launch",
 		"mode": "debug",
-		"program": "${workspaceFolder}",
-		"args": ["submit", "-p", "workloads/training/LLMs/lora-supervised-finetuning/ds-zero3-single-multinode", "--ray", "-g", "4"],
+		"program": "${workspaceFolder}/cmd/cli/main.go",
+		"args": ["submit", "-p", "${workspaceFolder}/workloads/training/LLMs/lora-supervised-finetuning/ds-zero3-single-multinode", "--ray", "-g", "4"],
 		"env": {
 		  "GO111MODULE": "on"
 		},
@@ -66,7 +66,7 @@
 		"type": "go",
 		"request": "launch",
 		"mode": "debug",
-		"program": "${workspaceFolder}",
+		"program": "${workspaceFolder}/cmd/cli/main.go",
 		"args": ["monitor", "deployment/avsuni-gpu-monitoring", "-n", "av-test"],
 		"env": {
 		  "GO111MODULE": "on"

--- a/README.md
+++ b/README.md
@@ -243,6 +243,22 @@ You can access this in the template via
 {{ .Custom.parent.child }}
 ```
 
+### Storage
+
+You can use the Kaiwo CLI to instruct a workload to use storage from a given storage class. If you do not provide any input for the CLI, the following default values are used:
+
+* The storage class name is read from the specified namespace's label `kaiwo-cli/default-storage-class`
+* The storage amount is read from the specified namespace's label `kaiwo-cli/default-storage-quantity`
+
+If these values do not exist, an exception is raised. If you are using the cluster-admins examples from this repository, you can modify the namespace at [cluster-admins/kueue/cluster-queue.yaml](cluster-admins/kueue/cluster-queue.yaml) and add these values. If you want to skip adding storage, you must explicitly add the `--no-storage` flag.
+
+To specify storage, you can use the flags:
+
+* `--storage=2Gi` to specify the amount of storage and to use the default storage class name from the namespace labels
+* `--storage=2Gi,mystorageclass` to specify both the amount of storage and the storage class name 
+
+Note that the storage created is ephemeral and meant for caching, which means that it gets removed when the underlying pods get removed. However, the ephemeral storage is provisioned via a storage class, which ensures that the space requested is available and reserved for all pods before the workload starts.
+
 ## Interacting with workloads
 
 While Kaiwo's primary purpose is to deploy workloads, it can also be used as a light tool to discover and interact with running workloads.

--- a/cluster-admins/kueue/cluster-queue.yaml
+++ b/cluster-admins/kueue/cluster-queue.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   namespaceSelector: {} # match all.
   resourceGroups:
-  - coveredResources: ["cpu", "memory", "amd.com/gpu", "ephemeral-storage"]
+  - coveredResources: ["cpu", "memory", "amd.com/gpu"]
     flavors:
     - name: base-gpu-flavour
       resources:
@@ -15,5 +15,3 @@ spec:
         nominalQuota: 1800Gi
       - name: "amd.com/gpu"
         nominalQuota: 16
-      - name: "ephemeral-storage"
-        nominalQuota: 2000Gi

--- a/pkg/cli/apply/serve.go
+++ b/pkg/cli/apply/serve.go
@@ -33,6 +33,9 @@ func BuildServeCmd() *cobra.Command {
 		Use:   "serve",
 		Short: "Serve a deployment process",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmd.Parent().PersistentPreRunE(cmd, args); err != nil {
+				return err
+			}
 			return PreRunLoadConfig(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/apply/submit.go
+++ b/pkg/cli/apply/submit.go
@@ -35,6 +35,9 @@ func BuildSubmitCmd() *cobra.Command {
 		Use:   "submit",
 		Short: "Submit a job",
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := cmd.Parent().PersistentPreRunE(cmd, args); err != nil {
+				return err
+			}
 			return PreRunLoadConfig(cmd, args)
 		},
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/pkg/cli/apply/utils.go
+++ b/pkg/cli/apply/utils.go
@@ -18,9 +18,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
-
-	"k8s.io/apimachinery/pkg/api/resource"
 
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -33,14 +30,12 @@ const defaultGpuNodeLabelKey = "beta.amd.com/gpu.family.AI"
 
 // Exec flags
 var (
-	dryRun           bool
-	createNamespace  bool
-	template         string
-	path             string
-	overlayPath      string
-	gpuNodeLabelKey  string
-	customConfigPath string
-	envFilePath      string
+	dryRun          bool
+	createNamespace bool
+	template        string
+	path            string
+	overlayPath     string
+	gpuNodeLabelKey string
 )
 
 // AddExecFlags adds flags that are needed for the execution of apply functions
@@ -52,8 +47,6 @@ func AddExecFlags(cmd *cobra.Command) {
 	// TODO: remove gpuNodeLabelKey and have this logic be handled by the operator
 	cmd.Flags().StringVarP(&gpuNodeLabelKey, "gpu-node-label-key", "", defaultGpuNodeLabelKey, fmt.Sprintf("Optional node label key used to specify the resource flavor GPU count. Defaults to %s", defaultGpuNodeLabelKey))
 	cmd.Flags().StringVarP(&template, "template", "t", "", "Optional path to a custom template to use for the workload. If not provided, a default template will be used unless template file found in workload directory")
-	cmd.Flags().StringVarP(&customConfigPath, "custom-config", "c", "", "Optional path to a custom YAML configuration file whose contents are made available in the template")
-	cmd.Flags().StringVarP(&envFilePath, "env-file", "", "", "Optional path to env file. Defaults to 'env' in workload code directory")
 }
 
 func GetExecFlags() workloads.ExecFlags {
@@ -64,8 +57,6 @@ func GetExecFlags() workloads.ExecFlags {
 		Path:                          path,
 		OverlayPath:                   overlayPath,
 		ResourceFlavorGpuNodeLabelKey: gpuNodeLabelKey,
-		CustomConfigPath:              customConfigPath,
-		EnvFilePath:                   envFilePath,
 	}
 }
 
@@ -191,10 +182,9 @@ type Config struct {
 	DryRun                  bool   `yaml:"dryRun"`
 	CreateNamespace         bool   `yaml:"createNamespace"`
 	Path                    string `yaml:"path"`
+	OverlayPath             string `yaml:"overlayPath"`
 	GpuNodeLabelKey         string `yaml:"gpuNodeLabelKey"`
 	Template                string `yaml:"template"`
-	CustomConfig            string `yaml:"customConfig"`
-	EnvFile                 string `yaml:"envFile"`
 	Name                    string `yaml:"name"`
 	Namespace               string `yaml:"namespace"`
 	Image                   string `yaml:"image"`
@@ -240,10 +230,9 @@ func ApplyConfigToFlags(cmd *cobra.Command, config *Config) {
 	setFlag("dry-run", fmt.Sprintf("%v", config.DryRun))
 	setFlag("create-namespace", fmt.Sprintf("%v", config.CreateNamespace))
 	setFlag("path", config.Path)
+	setFlag("overlay-path", config.OverlayPath)
 	setFlag("gpu-node-label-key", config.GpuNodeLabelKey)
 	setFlag("template", config.Template)
-	setFlag("custom-config", config.CustomConfig)
-	setFlag("env-file", config.EnvFile)
 
 	// MetaFlags
 	setFlag("name", config.Name)
@@ -259,13 +248,23 @@ func ApplyConfigToFlags(cmd *cobra.Command, config *Config) {
 }
 
 func PreRunLoadConfig(cmd *cobra.Command, _ []string) error {
-	if path == "" {
+	if path == "" && overlayPath == "" {
 		return nil
 	}
 
-	config, err := LoadConfigFromPath(path)
+	// First try to load config from the overlay path
+	config, err := LoadConfigFromPath(overlayPath)
 	if err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if config == nil {
+		// If no overlay, try the main path
+		config, err = LoadConfigFromPath(path)
+		if err != nil {
+			return fmt.Errorf("failed to load config: %w", err)
+		}
+		logrus.Infof("Loaded config from %s", path)
 	}
 
 	if config != nil {

--- a/pkg/cli/apply/utils.go
+++ b/pkg/cli/apply/utils.go
@@ -37,6 +37,7 @@ var (
 	createNamespace  bool
 	template         string
 	path             string
+	overlayPath      string
 	gpuNodeLabelKey  string
 	customConfigPath string
 	envFilePath      string
@@ -47,6 +48,7 @@ func AddExecFlags(cmd *cobra.Command) {
 	cmd.Flags().BoolVarP(&createNamespace, "create-namespace", "", false, "Create namespace if it does not exist")
 	cmd.Flags().BoolVarP(&dryRun, "dry-run", "d", false, "Print the generated workload manifest without submitting it")
 	cmd.Flags().StringVarP(&path, "path", "p", "", "Path to directory for workload code, entrypoint/serveconfig, env-file, etc. Either image or path is mandatory")
+	cmd.Flags().StringVarP(&overlayPath, "overlay-path", "o", "", "Additional overlay path. Files from both path and overlay-path are combined, if the file exists in both, the one from overlay-path is used")
 	// TODO: remove gpuNodeLabelKey and have this logic be handled by the operator
 	cmd.Flags().StringVarP(&gpuNodeLabelKey, "gpu-node-label-key", "", defaultGpuNodeLabelKey, fmt.Sprintf("Optional node label key used to specify the resource flavor GPU count. Defaults to %s", defaultGpuNodeLabelKey))
 	cmd.Flags().StringVarP(&template, "template", "t", "", "Optional path to a custom template to use for the workload. If not provided, a default template will be used unless template file found in workload directory")
@@ -60,6 +62,7 @@ func GetExecFlags() workloads.ExecFlags {
 		DryRun:                        dryRun,
 		Template:                      template,
 		Path:                          path,
+		OverlayPath:                   overlayPath,
 		ResourceFlavorGpuNodeLabelKey: gpuNodeLabelKey,
 		CustomConfigPath:              customConfigPath,
 		EnvFilePath:                   envFilePath,

--- a/pkg/k8s/utils.go
+++ b/pkg/k8s/utils.go
@@ -19,65 +19,12 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"slices"
 
 	"github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 )
-
-func isBinaryFile(content []byte) bool {
-	return bytes.Contains(content, []byte{0})
-}
-
-// GenerateConfigMapFromDir generates a ConfigMap from a directory
-func GenerateConfigMapFromDir(dir string, name string, namespace string, skipFiles []string) (*corev1.ConfigMap, error) {
-	files, err := os.ReadDir(dir)
-	if err != nil {
-		return nil, fmt.Errorf("failed to read directory: %w", err)
-	}
-
-	data := make(map[string]string)
-
-	for _, file := range files {
-		if file.IsDir() {
-			continue
-		}
-
-		if slices.Contains(skipFiles, file.Name()) {
-			continue
-		}
-
-		filePath := filepath.Join(dir, file.Name())
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
-		}
-
-		// Skip binary files
-		if isBinaryFile(content) {
-			logrus.Warnf("Skipping binary file: %s", file.Name())
-			continue
-		}
-		data[file.Name()] = string(content)
-	}
-
-	if len(data) == 0 {
-		return nil, nil
-	}
-
-	configMap := &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
-			Namespace: namespace,
-		},
-		Data: data,
-	}
-
-	return configMap, nil
-}
 
 type SecretVolume struct {
 	Name       string

--- a/pkg/tui/list/pod/select.go
+++ b/pkg/tui/list/pod/select.go
@@ -148,7 +148,7 @@ func runSelectAndDoAction(_ context.Context, _ k8s.KubernetesClients, state *tui
 
 	var (
 		viewLogsAction runAction = "View logs"
-		monitorAction  runAction = "Monitor"
+		monitorAction  runAction = "Monitor GPUs"
 		commandAction  runAction = "Run command"
 	)
 

--- a/pkg/tui/list/workload/delete.go
+++ b/pkg/tui/list/workload/delete.go
@@ -32,7 +32,9 @@ import (
 
 func runDeleteWorkload(ctx context.Context, clients k8s.KubernetesClients, state *tuicomponents.RunState) (tuicomponents.StepResult, tuicomponents.RunStep[tuicomponents.RunState], error) {
 	confirmDelete := false
-	resourceDescription := fmt.Sprintf("Confirm that you want to delete the %s workload '%s' in namespace %s", state.WorkloadType, state.WorkloadReference.GetName(), state.Namespace)
+	resourceDescription := fmt.Sprintf("Confirm that you want to delete the %s workload '%s' in namespace %s. "+
+		"This will also remove any linked resources, such as automatically created PVCs and ConfigMaps",
+		state.WorkloadType, state.WorkloadReference.GetName(), state.Namespace)
 
 	f := huh.NewForm(huh.NewGroup(huh.NewConfirm().Title(resourceDescription).Value(&confirmDelete)))
 

--- a/pkg/workloads/apply.go
+++ b/pkg/workloads/apply.go
@@ -15,11 +15,13 @@
 package workloads
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"strings"
 	"text/template"
 
@@ -64,7 +66,7 @@ func ApplyWorkload(
 	}
 
 	if execFlags.Path != "" {
-		configMapResource, err = generateConfigMapManifest(execFlags.Path, execFlags.OverlayPath, workload, templateContext.Meta)
+		configMapResource, err = generateConfigMapManifest(execFlags.WorkloadFiles, workload, templateContext.Meta)
 		if err != nil {
 			return fmt.Errorf("failed to generate configmap resource: %w", err)
 		}
@@ -201,34 +203,54 @@ func generateNamespaceManifestIfNotExists(
 	}, nil
 }
 
+func isBinaryFile(content []byte) bool {
+	return bytes.Contains(content, []byte{0})
+}
+
 // generateConfigMapManifest adds a config map resource
-func generateConfigMapManifest(path string, overlayPath string, workload Workload, metaConfig MetaFlags) (*corev1.ConfigMap, error) {
-	configMap, err := k8s.GenerateConfigMapFromDir(path, metaConfig.Name, metaConfig.Namespace, workload.IgnoreFiles())
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate ConfigMap from path: %w", err)
+func generateConfigMapManifest(files map[string]string, workload Workload, metaConfig MetaFlags) (*corev1.ConfigMap, error) {
+	configMap := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      metaConfig.Name,
+			Namespace: metaConfig.Namespace,
+		},
+		Data: map[string]string{},
 	}
 
-	if overlayPath != "" {
-		overlayConfigMap, err := k8s.GenerateConfigMapFromDir(overlayPath, metaConfig.Name, metaConfig.Namespace, workload.IgnoreFiles())
+	skipFiles := workload.IgnoreFiles()
+
+	for fileName, filePath := range files {
+		if slices.Contains(skipFiles, fileName) {
+			continue
+		}
+
+		info, err := os.Stat(filePath)
 		if err != nil {
-			return nil, fmt.Errorf("failed to generate ConfigMap from overlay path: %w", err)
+			return nil, fmt.Errorf("failed to stat file %s: %w", filePath, err)
 		}
 
-		if configMap == nil {
-			configMap = overlayConfigMap
+		if info.Size() > 950e3 {
+			logrus.Warnf("Skipping file %s in %s as it is too large", fileName, filePath)
+			continue
 		}
 
-		if overlayConfigMap != nil {
-			for k, v := range overlayConfigMap.Data {
-				// Override values
-				configMap.Data[k] = v
-			}
+		content, err := os.ReadFile(filePath)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read file %s: %w", filePath, err)
 		}
+
+		// Skip binary files
+		if isBinaryFile(content) {
+			logrus.Warnf("Skipping binary file %s in %s", fileName, filePath)
+			continue
+		}
+		configMap.Data[fileName] = string(content)
 	}
 
-	if configMap != nil {
+	if len(configMap.Data) > 0 {
 		return configMap, nil
 	}
+
 	return nil, nil
 }
 

--- a/pkg/workloads/config.go
+++ b/pkg/workloads/config.go
@@ -114,6 +114,9 @@ type ExecFlags struct {
 	// Path to workload folder
 	Path string
 
+	// OverlayPath contains specific files that override files in Path
+	OverlayPath string
+
 	// The key used to store the GPU count per node in the resource flavor
 	ResourceFlavorGpuNodeLabelKey string
 

--- a/pkg/workloads/config.go
+++ b/pkg/workloads/config.go
@@ -26,6 +26,7 @@ const (
 	KaiwoUsernameLabel                = "kaiwo-cli/username"
 	KaiwoDefaultStorageClassNameLabel = "kaiwo-cli/default-storage-class-name"
 	KaiwoDefaultStorageQuantityLabel  = "kaiwo-cli/default-storage-quantity"
+	CustomTemplateValuesFilename = "custom-template-values.yaml"
 )
 
 // WorkloadTemplateConfig is the config context that is passed to the workload templates
@@ -120,9 +121,7 @@ type ExecFlags struct {
 	// The key used to store the GPU count per node in the resource flavor
 	ResourceFlavorGpuNodeLabelKey string
 
-	// Path to custom config file
-	CustomConfigPath string
-
-	// Path to env file if not in Path
-	EnvFilePath string
+	// WorkloadFiles list the files that are considered to be part of the workload after merging Path and OverlayPath
+	// The map is from the workload path (how the workload would see it) to the true relative path (how the CLI client sees it)
+	WorkloadFiles map[string]string
 }

--- a/pkg/workloads/config.go
+++ b/pkg/workloads/config.go
@@ -21,9 +21,11 @@ import (
 )
 
 const (
-	KaiwoconfigFilename = "kaiwoconfig"
-	EnvFilename         = "env"
-	KaiwoUsernameLabel  = "kaiwo-cli/username"
+	KaiwoconfigFilename               = "kaiwoconfig"
+	EnvFilename                       = "env"
+	KaiwoUsernameLabel                = "kaiwo-cli/username"
+	KaiwoDefaultStorageClassNameLabel = "kaiwo-cli/default-storage-class-name"
+	KaiwoDefaultStorageQuantityLabel  = "kaiwo-cli/default-storage-quantity"
 )
 
 // WorkloadTemplateConfig is the config context that is passed to the workload templates
@@ -61,6 +63,13 @@ type SchedulingFlags struct {
 
 	// CalculatedNumReplicas refers to the number of replicas, calculated from the available GPUs per node
 	CalculatedNumReplicas int
+
+	Storage *StorageSchedulingFlags
+}
+
+type StorageSchedulingFlags struct {
+	Quantity         string
+	StorageClassName string
 }
 
 // MetaFlags contain flags that are shared by all workloads

--- a/pkg/workloads/deployments/deployment.go
+++ b/pkg/workloads/deployments/deployment.go
@@ -19,7 +19,6 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -43,7 +42,7 @@ type DeploymentFlags struct {
 }
 
 func (deployment Deployment) GenerateTemplateContext(execFlags workloads.ExecFlags) (any, error) {
-	contents, err := os.ReadFile(filepath.Join(execFlags.Path, EntrypointFilename))
+	contents, err := os.ReadFile(execFlags.WorkloadFiles[EntrypointFilename])
 	if err != nil {
 		if os.IsNotExist(err) {
 			logrus.Warnln("No entrypoint file found. Expecting entrypoint in image")

--- a/pkg/workloads/deployments/deployment.go
+++ b/pkg/workloads/deployments/deployment.go
@@ -62,7 +62,7 @@ func (deployment Deployment) GenerateTemplateContext(execFlags workloads.ExecFla
 	return DeploymentFlags{Entrypoint: entrypoint}, nil
 }
 
-func (deployment Deployment) ConvertObject(object runtime.Object) (runtime.Object, bool) {
+func (deployment Deployment) ConvertObject(object runtime.Object) (client.Object, bool) {
 	obj, ok := object.(*appsv1.Deployment)
 	return obj, ok
 }

--- a/pkg/workloads/deployments/deployment.yaml.tmpl
+++ b/pkg/workloads/deployments/deployment.yaml.tmpl
@@ -31,6 +31,8 @@ spec:
         - {{ .Workload.Entrypoint }}
         {{- end }}
         env:
+          - name: HF_HOME
+            value: /workload/.cache/huggingface
         {{- if .Meta.EnvVars }}
         {{- range .Meta.EnvVars }}
         {{- if .Value }}
@@ -59,6 +61,8 @@ spec:
             amd.com/gpu: "{{ .Scheduling.TotalRequestedGPUs }}"
             {{ end }}
         volumeMounts:
+          - mountPath: /workload
+            name: {{ .Meta.Name }}-main
         {{- if .Meta.SecretVolumes }}
         {{- range .Meta.SecretVolumes }}
           - name: {{ .Name }}
@@ -67,12 +71,28 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Meta.HasConfigMap }}
-          - mountPath: /workload
-            name: workload
+          - mountPath: /workload/mounted
+            name: workload-mount
         {{- end }}
           - mountPath: /dev/shm
             name: dshm
       volumes:
+      {{- if .Scheduling.Storage }}
+        - name: {{ .Meta.Name }}-main
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes: [ "ReadWriteOnce" ]
+                storageClassName: {{ .Scheduling.Storage.StorageClassName }}
+                resources:
+                  requests:
+                    storage: {{ .Scheduling.Storage.Quantity }}
+      {{- else }}
+        - name: {{ .Meta.Name }}-main
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Mi
+      {{- end }}
       {{- if .Meta.SecretVolumes }}
       {{- range .Meta.SecretVolumes }}
         - name: {{ .Name }}
@@ -84,7 +104,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Meta.HasConfigMap }}
-        - name: workload
+        - name: workload-mount
           configMap:
             name: {{ .Meta.Name }}
       {{- end }}

--- a/pkg/workloads/jobs/job.go
+++ b/pkg/workloads/jobs/job.go
@@ -68,7 +68,7 @@ func (job Job) DefaultTemplate() ([]byte, error) {
 	return JobTemplate, nil
 }
 
-func (job Job) ConvertObject(object runtime.Object) (runtime.Object, bool) {
+func (job Job) ConvertObject(object runtime.Object) (client.Object, bool) {
 	obj, ok := object.(*batchv1.Job)
 	return obj, ok
 }

--- a/pkg/workloads/jobs/job.go
+++ b/pkg/workloads/jobs/job.go
@@ -19,7 +19,6 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/sirupsen/logrus"
@@ -43,7 +42,7 @@ type JobFlags struct {
 }
 
 func (job Job) GenerateTemplateContext(execFlags workloads.ExecFlags) (any, error) {
-	contents, err := os.ReadFile(filepath.Join(execFlags.Path, EntrypointFilename))
+	contents, err := os.ReadFile(execFlags.WorkloadFiles[EntrypointFilename])
 	if err != nil {
 		if os.IsNotExist(err) {
 			logrus.Warnln("No entrypoint file found. Expecting entrypoint in image")

--- a/pkg/workloads/jobs/job.yaml.tmpl
+++ b/pkg/workloads/jobs/job.yaml.tmpl
@@ -26,6 +26,8 @@ spec:
         - {{ .Workload.Entrypoint }}
         {{- end }}
         env:
+          - name: HF_HOME
+            value: /workload/.cache/huggingface
         {{- if .Meta.EnvVars }}
         {{- range .Meta.EnvVars }}
         {{- if .Value }}
@@ -50,6 +52,8 @@ spec:
             cpu: "{{ mul .Scheduling.TotalRequestedGPUs 4 }}"
             amd.com/gpu: "{{ .Scheduling.TotalRequestedGPUs }}"
         volumeMounts:
+          - mountPath: /workload
+            name: {{ .Meta.Name }}-main
         {{- if .Meta.SecretVolumes }}
         {{- range .Meta.SecretVolumes }}
           - name: {{ .Name }}
@@ -58,12 +62,28 @@ spec:
         {{- end }}
         {{- end }}
         {{- if .Meta.HasConfigMap }}
-          - mountPath: /workload
-            name: workload
+          - mountPath: /workload/mounted
+            name: workload-mount
         {{- end }}
           - mountPath: /dev/shm
             name: dshm
       volumes:
+      {{- if .Scheduling.Storage }}
+        - name: {{ .Meta.Name }}-main
+          ephemeral:
+            volumeClaimTemplate:
+              spec:
+                accessModes: [ "ReadWriteOnce" ]
+                storageClassName: {{ .Scheduling.Storage.StorageClassName }}
+                resources:
+                  requests:
+                    storage: {{ .Scheduling.Storage.Quantity }}
+      {{- else }}
+        - name: {{ .Meta.Name }}-main
+          emptyDir:
+            medium: Memory
+            sizeLimit: 10Mi
+      {{- end }}
       {{- if .Meta.SecretVolumes }}
       {{- range .Meta.SecretVolumes }}
         - name: {{ .Name }}
@@ -75,7 +95,7 @@ spec:
       {{- end }}
       {{- end }}
       {{- if .Meta.HasConfigMap }}
-        - name: workload
+        - name: workload-mount
           configMap:
             name: {{ .Meta.Name }}
       {{- end }}
@@ -83,4 +103,3 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 200Gi
-

--- a/pkg/workloads/ray/deployment.go
+++ b/pkg/workloads/ray/deployment.go
@@ -19,7 +19,6 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
@@ -43,9 +42,7 @@ var DeploymentTemplate []byte
 const ServeconfigFilename = "serveconfig"
 
 func (deployment Deployment) GenerateTemplateContext(execFlags workloads.ExecFlags) (any, error) {
-	logrus.Debugf("Loading ray service from %s", execFlags.Path)
-
-	contents, err := os.ReadFile(filepath.Join(execFlags.Path, ServeconfigFilename))
+	contents, err := os.ReadFile(execFlags.WorkloadFiles[ServeconfigFilename])
 	if err != nil {
 		return nil, fmt.Errorf("failed to read serveconfig file: %w", err)
 	}

--- a/pkg/workloads/ray/deployment.go
+++ b/pkg/workloads/ray/deployment.go
@@ -53,7 +53,36 @@ func (deployment Deployment) GenerateTemplateContext(execFlags workloads.ExecFla
 	return DeploymentFlags{Serveconfig: strings.TrimSpace(string(contents))}, nil
 }
 
-func (deployment Deployment) ConvertObject(object runtime.Object) (runtime.Object, bool) {
+//func (deployment Deployment) BuildObject(flags workloads.WorkloadTemplateConfig) (client.Object, error) {
+//	obj := &rayv1.RayService{
+//		ObjectMeta: metav1.ObjectMeta{
+//			Name:      flags.Meta.Name,
+//			Namespace: flags.Meta.Namespace,
+//			Labels: map[string]string{
+//				"kaiwo-cli/username": flags.Meta.User,
+//			},
+//		},
+//		Spec: rayv1.RayServiceSpec{
+//			ServeConfigV2: "",
+//			RayClusterSpec: rayv1.RayClusterSpec{
+//				// EnableInTreeAutoscaling: true,
+//				HeadGroupSpec: rayv1.HeadGroupSpec{
+//					RayStartParams: map[string]string{
+//						"dashboard-host": "0.0.0.0",
+//					},
+//					Template: corev1.PodTemplateSpec{},
+//				},
+//			},
+//		},
+//	}
+//	return obj, nil
+//}
+//
+//func buildPodSpec(metaFlags workloads.MetaFlags, ports []corev1.ContainerPort) corev1.PodSpec {
+//	return corev1.PodSpec{}
+//}
+
+func (deployment Deployment) ConvertObject(object runtime.Object) (client.Object, bool) {
 	obj, ok := object.(*rayv1.RayService)
 
 	return obj, ok

--- a/pkg/workloads/ray/deployment.yaml.tmpl
+++ b/pkg/workloads/ray/deployment.yaml.tmpl
@@ -24,6 +24,8 @@ spec:
               image: {{ .Meta.Image }}
               imagePullPolicy: Always
               env:
+                - name: HF_HOME
+                  value: /workload/.cache/huggingface
               {{- if .Meta.EnvVars }}
               {{- range .Meta.EnvVars }}
               {{- if .Value }}
@@ -46,6 +48,8 @@ spec:
                   cpu: "2"
                   memory: "16Gi"
               volumeMounts:
+                - mountPath: /workload
+                  name: {{ .Meta.Name }}-main
               {{- if .Meta.SecretVolumes }}
               {{- range .Meta.SecretVolumes }}
                 - name: {{ .Name }}
@@ -54,8 +58,8 @@ spec:
               {{- end }}
               {{- end }}
               {{- if .Meta.HasConfigMap }}
-                - mountPath: /workload/app
-                  name: workload
+                - mountPath: /workload/mounted
+                  name: workload-mount
               {{- end }}
                 - mountPath: /dev/shm
                   name: dshm
@@ -69,6 +73,22 @@ spec:
                 - containerPort: 8000
                   name: serve
           volumes:
+          {{- if .Scheduling.Storage }}
+            - name: {{ .Meta.Name }}-main
+              ephemeral:
+                volumeClaimTemplate:
+                  spec:
+                    accessModes: [ "ReadWriteOnce" ]
+                    storageClassName: {{ .Scheduling.Storage.StorageClassName }}
+                    resources:
+                      requests:
+                        storage: 10Mi
+          {{- else }}
+            - name: {{ .Meta.Name }}-main
+              emptyDir:
+                medium: Memory
+                sizeLimit: 10Mi
+          {{- end }}
           {{- if .Meta.SecretVolumes }}
           {{- range .Meta.SecretVolumes }}
             - name: {{ .Name }}
@@ -80,7 +100,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Meta.HasConfigMap }}
-            - name: workload
+            - name: workload-mount
               configMap:
                 name: {{ .Meta.Name }}
           {{- end }}
@@ -109,6 +129,8 @@ spec:
                     exec:
                       command: ["/bin/sh", "-c", "ray stop"]
                 env:
+                  - name: HF_HOME
+                    value: /workload/.cache/huggingface
                 {{- if .Meta.EnvVars }}
                 {{- range .Meta.EnvVars }}
                 {{- if .Value }}
@@ -133,6 +155,8 @@ spec:
                         memory: "{{ mul .Scheduling.CalculatedGPUsPerReplica 32 }}Gi"
                         amd.com/gpu: "{{ .Scheduling.CalculatedGPUsPerReplica }}"
                 volumeMounts:
+                  - mountPath: /workload
+                    name: {{ .Meta.Name }}-main
                 {{- if .Meta.SecretVolumes }}
                 {{- range .SecretVolumes }}
                   - name: {{ .Name }}
@@ -141,12 +165,28 @@ spec:
                 {{- end }}
                 {{- end }}
                 {{- if .Meta.HasConfigMap }}
-                  - mountPath: /workload/app
-                    name: workload
+                  - mountPath: /workload/mounted
+                    name: workload-mount
                 {{- end }}
                   - mountPath: /dev/shm
                     name: dshm
             volumes:
+            {{- if .Scheduling.Storage }}
+              - name: {{ .Meta.Name }}-main
+                ephemeral:
+                  volumeClaimTemplate:
+                    spec:
+                      accessModes: [ "ReadWriteOnce" ]
+                      storageClassName: {{ .Scheduling.Storage.StorageClassName }}
+                      resources:
+                        requests:
+                          storage: {{ .Scheduling.Storage.Quantity }}
+            {{- else }}
+              - name: {{ .Meta.Name }}-main
+                emptyDir:
+                  medium: Memory
+                  sizeLimit: 10Mi
+            {{- end }}
             {{- if .Meta.SecretVolumes }}
             {{- range .Meta.SecretVolumes }}
               - name: {{ .Name }}
@@ -158,7 +198,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Meta.HasConfigMap }}
-              - name: workload
+              - name: workload-mount
                 configMap:
                   name: {{ .Meta.Name }}
             {{- end }}

--- a/pkg/workloads/ray/job.go
+++ b/pkg/workloads/ray/job.go
@@ -19,12 +19,12 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	rayv1 "github.com/ray-project/kuberay/ray-operator/apis/ray/v1"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/silogen/kaiwo/pkg/workloads"
@@ -42,7 +42,7 @@ type JobFlags struct {
 }
 
 func (job Job) GenerateTemplateContext(execFlags workloads.ExecFlags) (any, error) {
-	contents, err := os.ReadFile(filepath.Join(execFlags.Path, EntrypointFilename))
+	contents, err := os.ReadFile(execFlags.WorkloadFiles[EntrypointFilename])
 	if err != nil {
 		return nil, fmt.Errorf("failed to read entrypoint file: %w", err)
 	}

--- a/pkg/workloads/ray/job.go
+++ b/pkg/workloads/ray/job.go
@@ -57,7 +57,7 @@ func (job Job) DefaultTemplate() ([]byte, error) {
 	return JobTemplate, nil
 }
 
-func (job Job) ConvertObject(object runtime.Object) (runtime.Object, bool) {
+func (job Job) ConvertObject(object runtime.Object) (client.Object, bool) {
 	obj, ok := object.(*rayv1.RayJob)
 	return obj, ok
 }

--- a/pkg/workloads/ray/job.yaml.tmpl
+++ b/pkg/workloads/ray/job.yaml.tmpl
@@ -17,6 +17,10 @@ spec:
       rayStartParams: {}
       template:
         spec:
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 1000
+            fsGroup: 1000
           {{- if .Meta.ImagePullSecret }}
           imagePullSecrets:
           - name: {{ .Meta.ImagePullSecret }}
@@ -26,6 +30,8 @@ spec:
               image: {{ .Meta.Image }}
               imagePullPolicy: Always
               env:
+                - name: HF_HOME
+                  value: /workload/.cache/huggingface
               {{- if .Meta.EnvVars }}
               {{- range .Meta.EnvVars }}
               {{- if .Value }}
@@ -55,6 +61,8 @@ spec:
                 - containerPort: 10001
                   name: client
               volumeMounts:
+                - mountPath: /workload
+                  name: {{ .Meta.Name }}-main
               {{- if .Meta.SecretVolumes }}
               {{- range .Meta.SecretVolumes }}
                 - name: {{ .Name }}
@@ -63,12 +71,28 @@ spec:
               {{- end }}
               {{- end }}
               {{- if .Meta.HasConfigMap }}
-                - mountPath: /workload
-                  name: workload
+                - mountPath: /workload/mounted
+                  name: workload-mount
               {{- end }}
                 - mountPath: /dev/shm
                   name: dshm
           volumes:
+          {{- if .Scheduling.Storage }}
+            - name: {{ .Meta.Name }}-main
+              ephemeral:
+                volumeClaimTemplate:
+                  spec:
+                    accessModes: [ "ReadWriteOnce" ]
+                    storageClassName: {{ .Scheduling.Storage.StorageClassName }}
+                    resources:
+                      requests:
+                        storage: 10Mi
+          {{- else }}
+            - name: {{ .Meta.Name }}-main
+              emptyDir:
+                medium: Memory
+                sizeLimit: 10Mi
+          {{- end }}
           {{- if .Meta.SecretVolumes }}
           {{- range .Meta.SecretVolumes }}
             - name: {{ .Name }}
@@ -80,7 +104,7 @@ spec:
           {{- end }}
           {{- end }}
           {{- if .Meta.HasConfigMap }}
-            - name: workload
+            - name: workload-mount
               configMap:
                 name: {{ .Meta.Name }}
           {{- end }}
@@ -97,6 +121,10 @@ spec:
         rayStartParams: {}
         template:
           spec:
+            securityContext:
+              runAsUser: 1000
+              runAsGroup: 1000
+              fsGroup: 1000
             {{- if .Meta.ImagePullSecret }}
             imagePullSecrets:
             - name: {{ .Meta.ImagePullSecret }}
@@ -106,6 +134,8 @@ spec:
                 image: {{ .Meta.Image }}
                 imagePullPolicy: Always
                 env:
+                  - name: HF_HOME
+                    value: /workload/.cache/huggingface
                 {{- if .Meta.EnvVars }}
                 {{- range .Meta.EnvVars }}
                 {{- if .Value }}
@@ -137,6 +167,8 @@ spec:
                         memory: "{{ mul .Scheduling.CalculatedGPUsPerReplica 32 }}Gi"
                         amd.com/gpu: "{{ .Scheduling.CalculatedGPUsPerReplica }}"
                 volumeMounts:
+                  - mountPath: /workload
+                    name: {{ .Meta.Name }}-main
                 {{- if .Meta.SecretVolumes }}
                 {{- range .Meta.SecretVolumes }}
                   - name: {{ .Name }}
@@ -145,12 +177,28 @@ spec:
                 {{- end }}
                 {{- end }}
                 {{- if .Meta.HasConfigMap }}
-                  - mountPath: /workload
-                    name: workload
+                  - mountPath: /workload/mounted
+                    name: workload-mount
                 {{- end }}
                   - mountPath: /dev/shm
                     name: dshm
             volumes:
+            {{- if .Scheduling.Storage }}
+              - name: {{ .Meta.Name }}-main
+                ephemeral:
+                  volumeClaimTemplate:
+                    spec:
+                      accessModes: [ "ReadWriteOnce" ]
+                      storageClassName: {{ .Scheduling.Storage.StorageClassName }}
+                      resources:
+                        requests:
+                          storage: {{ .Scheduling.Storage.Quantity }}
+            {{- else }}
+              - name: {{ .Meta.Name }}-main
+                emptyDir:
+                  medium: Memory
+                  sizeLimit: 10Mi
+            {{- end }}
             {{- if.Meta.SecretVolumes }}
             {{- range .Meta.SecretVolumes }}
               - name: {{ .Name }}
@@ -162,7 +210,7 @@ spec:
             {{- end }}
             {{- end }}
             {{- if .Meta.HasConfigMap }}
-              - name: workload
+              - name: workload-mount
                 configMap:
                   name: {{ .Meta.Name }}
             {{- end }}

--- a/pkg/workloads/workload.go
+++ b/pkg/workloads/workload.go
@@ -33,7 +33,7 @@ type Workload interface {
 	// DefaultTemplate returns a default template to use for this workload
 	DefaultTemplate() ([]byte, error)
 
-	ConvertObject(object runtime.Object) (runtime.Object, bool)
+	ConvertObject(object runtime.Object) (client.Object, bool)
 
 	// IgnoreFiles lists the files that should be ignored in the ConfigMap
 	IgnoreFiles() []string

--- a/workloads/inference/LLMs/offline-inference/vllm-batch-single-multinode/entrypoint
+++ b/workloads/inference/LLMs/offline-inference/vllm-batch-single-multinode/entrypoint
@@ -1,1 +1,1 @@
-python main.py
+python mounted/main.py

--- a/workloads/inference/LLMs/online-inference/vllm-online-single-multinode/serveconfig
+++ b/workloads/inference/LLMs/online-inference/vllm-online-single-multinode/serveconfig
@@ -1,7 +1,7 @@
 applications:
 - name: llm
   route_prefix: /
-  import_path: app:deployment
+  import_path: mounted:deployment
   deployments:
   - name: VLLMDeployment
     autoscaling_config:

--- a/workloads/training/LLMs/full-parameter-pretraining/full-param-zero3-single-multinode/entrypoint
+++ b/workloads/training/LLMs/full-parameter-pretraining/full-param-zero3-single-multinode/entrypoint
@@ -1,6 +1,6 @@
-python main.py
+python mounted/main.py
 --model-name=meta-llama/Llama-3.1-8B-Instruct
---ds-config=./zero_3_offload_optim_param.json
+--ds-config=./mounted/zero_3_offload_optim_param.json
 --bucket=silogen-dev-ray
 --num-epochs=2
 --num-devices=$NUM_GPUS

--- a/workloads/training/LLMs/lora-supervised-finetuning/lora-sft-zero3-single-multinode/entrypoint
+++ b/workloads/training/LLMs/lora-supervised-finetuning/lora-sft-zero3-single-multinode/entrypoint
@@ -1,6 +1,7 @@
-python main.py
+python mounted/main.py
 --model-name=meta-llama/Llama-3.1-8B-Instruct
---ds-config=./zero_3_offload_optim_param.json
+--ds-config=./mounted/zero_3_offload_optim_param.json
+--lora-config=./mounted/lora-llama.json
 --bucket=silogen-dev-ray
 --num-epochs=2
 --lora


### PR DESCRIPTION
# Description

Added an `--overlay-path` that allows users to combine files from two different directories.

Fixes #60 

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [ ] Existing workload examples run after my changes (if applicable)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes