### PR TITLE
merge Workload and WorkloadReference interfaces together

### DIFF
--- a/pkg/cli/apply/serve.go
+++ b/pkg/cli/apply/serve.go
@@ -46,10 +46,10 @@ func BuildServeCmd() *cobra.Command {
 			}
 
 			if useRayForServe {
-				deployment = ray.Deployment{}
+				deployment = &ray.Deployment{}
 				logrus.Debugln("Using RayService for deployment")
 			} else {
-				deployment = deployments.Deployment{}
+				deployment = &deployments.Deployment{}
 			}
 
 			return RunApply(deployment, deploymentFlags)

--- a/pkg/cli/apply/submit.go
+++ b/pkg/cli/apply/submit.go
@@ -49,9 +49,9 @@ func BuildSubmitCmd() *cobra.Command {
 
 			if useRayForJob {
 				logrus.Debugln("Using RayJob for job")
-				job = ray.Job{}
+				job = &ray.Job{}
 			} else {
-				job = jobs.Job{}
+				job = &jobs.Job{}
 			}
 			return RunApply(job, jobFlags)
 		},

--- a/pkg/cli/exec.go
+++ b/pkg/cli/exec.go
@@ -98,12 +98,11 @@ func executeContainerCommand(args []string, command []string, gpuPodsOnly bool) 
 		return fmt.Errorf("failed to get k8s clients: %w", err)
 	}
 
-	reference, err := workload.BuildReference(ctx, clients.Client, objectKey)
-	if err != nil {
+	if err := workload.LoadFromObjectKey(ctx, clients.Client, objectKey); err != nil {
 		return fmt.Errorf("failed to build workload reference: %w", err)
 	}
 
-	allPods := reference.GetPods()
+	allPods := workload.ListKnownPods()
 	if len(allPods) == 0 {
 		return fmt.Errorf("no pods found for workload %s", args[0])
 	}
@@ -114,7 +113,7 @@ func executeContainerCommand(args []string, command []string, gpuPodsOnly bool) 
 		predicates = []utils.PodSelectionPredicate{utils.IsGPUPod}
 	}
 
-	podName, containerName, err, cancelled := list.ChoosePodAndContainer(ctx, *clients, reference, predicates...)
+	podName, containerName, err, cancelled := list.ChoosePodAndContainer(ctx, *clients, workload, predicates...)
 	if err != nil {
 		return fmt.Errorf("failed to choose pod and container: %w", err)
 	}

--- a/pkg/cli/logs.go
+++ b/pkg/cli/logs.go
@@ -72,12 +72,11 @@ func executeLogsCommand(_ *cobra.Command, args []string) error {
 		return fmt.Errorf("failed to get k8s clients: %w", err)
 	}
 
-	workloadReference, err := workload.BuildReference(ctx, clients.Client, objectKey)
-	if err != nil {
+	if err := workload.LoadFromObjectKey(ctx, clients.Client, objectKey); err != nil {
 		return fmt.Errorf("failed to build workload reference: %w", err)
 	}
 
-	podName, containerName, err, cancelled := list.ChoosePodAndContainer(ctx, *clients, workloadReference)
+	podName, containerName, err, cancelled := list.ChoosePodAndContainer(ctx, *clients, workload)
 
 	if err != nil {
 		return fmt.Errorf("failed to choose pod and container: %w", err)

--- a/pkg/k8s/kueue.go
+++ b/pkg/k8s/kueue.go
@@ -173,8 +173,8 @@ func GetClusterQueue(ctx context.Context, k8sClient client.Client, clusterQueueN
 	return clusterQueue, nil
 }
 
-func PrepareLocalQueue(queueName string, namespace string, k8sClient client.Client) (*kueuev1beta1.LocalQueue, error) {
-	_, err := GetClusterQueue(context.TODO(), k8sClient, queueName)
+func PrepareLocalClusterQueue(ctx context.Context, queueName string, namespace string, k8sClient client.Client) (*kueuev1beta1.LocalQueue, error) {
+	_, err := GetClusterQueue(ctx, k8sClient, queueName)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get default cluster queue: %w", err)
 	}

--- a/pkg/tui/components/state.go
+++ b/pkg/tui/components/state.go
@@ -21,7 +21,7 @@ import (
 
 type RunState struct {
 	WorkloadType           string
-	WorkloadReference      workloads.WorkloadReference
+	Workload               workloads.Workload
 	User                   string
 	Namespace              string
 	PodName                string

--- a/pkg/tui/list/app.go
+++ b/pkg/tui/list/app.go
@@ -38,7 +38,7 @@ func RunList(workloadType string, workloadName string, namespace string, user st
 
 	ctx := context.Background()
 
-	var workloadReference workloads.WorkloadReference
+	var workloadReference workloads.Workload
 
 	if workloadName != "" {
 		// If the workload name is set, attempt to load the workload reference
@@ -46,17 +46,17 @@ func RunList(workloadType string, workloadName string, namespace string, user st
 		if err != nil {
 			return fmt.Errorf("failed to get workload: %w", err)
 		}
-		workloadReference, err = workload.BuildReference(ctx, k8sClient, objectKey)
-		if err != nil {
+
+		if err := workload.LoadFromObjectKey(ctx, k8sClient, objectKey); err != nil {
 			return fmt.Errorf("failed to build workload reference: %w", err)
 		}
 	}
 
 	runState := &tuicomponents.RunState{
-		WorkloadType:      workloadType,
-		WorkloadReference: workloadReference,
-		User:              user,
-		Namespace:         namespace,
+		WorkloadType: workloadType,
+		Workload:     workloadReference,
+		User:         user,
+		Namespace:    namespace,
 	}
 
 	clients, err := k8s.GetKubernetesClients()

--- a/pkg/tui/list/pod/exec.go
+++ b/pkg/tui/list/pod/exec.go
@@ -65,7 +65,7 @@ func runCommandAction(ctx context.Context, clients k8s.KubernetesClients, state 
 		clients.Kubeconfig,
 		state.PodName,
 		state.ContainerName,
-		state.WorkloadReference.GetNamespace(),
+		state.Workload.GetNamespace(),
 		command,
 		execInteractive,
 		execTTY,

--- a/pkg/tui/list/pod/logs.go
+++ b/pkg/tui/list/pod/logs.go
@@ -54,7 +54,7 @@ func runViewLogsAction(ctx context.Context, clients k8s.KubernetesClients, state
 		break
 	}
 
-	if err := utils.OutputLogs(ctx, clients.Clientset, state.PodName, state.ContainerName, int64(numLines), state.WorkloadReference.GetNamespace(), follow); err != nil {
+	if err := utils.OutputLogs(ctx, clients.Clientset, state.PodName, state.ContainerName, int64(numLines), state.Workload.GetNamespace(), follow); err != nil {
 		return tuicomponents.StepResultErr, nil, fmt.Errorf("failed to output the logs: %w", err)
 	}
 

--- a/pkg/tui/list/pod/monitor.go
+++ b/pkg/tui/list/pod/monitor.go
@@ -35,7 +35,7 @@ func runMonitorAction(ctx context.Context, clients k8s.KubernetesClients, state 
 		clients.Kubeconfig,
 		state.PodName,
 		state.ContainerName,
-		state.WorkloadReference.GetNamespace(),
+		state.Workload.GetNamespace(),
 		command,
 		true,
 		true,

--- a/pkg/tui/list/workload/delete.go
+++ b/pkg/tui/list/workload/delete.go
@@ -34,7 +34,7 @@ func runDeleteWorkload(ctx context.Context, clients k8s.KubernetesClients, state
 	confirmDelete := false
 	resourceDescription := fmt.Sprintf("Confirm that you want to delete the %s workload '%s' in namespace %s. "+
 		"This will also remove any linked resources, such as automatically created PVCs and ConfigMaps",
-		state.WorkloadType, state.WorkloadReference.GetName(), state.Namespace)
+		state.WorkloadType, state.Workload.GetName(), state.Namespace)
 
 	f := huh.NewForm(huh.NewGroup(huh.NewConfirm().Title(resourceDescription).Value(&confirmDelete)))
 
@@ -51,7 +51,7 @@ func runDeleteWorkload(ctx context.Context, clients k8s.KubernetesClients, state
 	deletePropagationPolicy := client.PropagationPolicy(metav1.DeletePropagationBackground)
 
 	deleteWorkload := func() {
-		err = clients.Client.Delete(ctx, state.WorkloadReference.GetObject(), deletePropagationPolicy)
+		err = clients.Client.Delete(ctx, state.Workload.GetObject(), deletePropagationPolicy)
 	}
 
 	if spinnerErr := spinner.New().Title("Deleting workload").Action(deleteWorkload).Run(); spinnerErr != nil {
@@ -62,7 +62,7 @@ func runDeleteWorkload(ctx context.Context, clients k8s.KubernetesClients, state
 		return tuicomponents.StepResultErr, nil, fmt.Errorf("failed to delete workload: %w", err)
 	}
 
-	logrus.Infof("Successfully deleted workload %s/%s", state.WorkloadType, state.WorkloadReference.GetName())
+	logrus.Infof("Successfully deleted workload %s/%s", state.WorkloadType, state.Workload.GetName())
 
 	// Quit as otherwise would need to return two screens, TODO make it possible to implement a custom number of return steps later
 	return tuicomponents.StepResultQuit, nil, nil

--- a/pkg/tui/list/workload/portforward.go
+++ b/pkg/tui/list/workload/portforward.go
@@ -43,12 +43,12 @@ import (
 // runPortForward runs the main target selection and port forwarding routine
 // TODO remove container ports if they are defined by a service
 func runPortForward(ctx context.Context, clients k8s.KubernetesClients, state *tuicomponents.RunState) (tuicomponents.StepResult, tuicomponents.RunStep[tuicomponents.RunState], error) {
-	workloadReference := state.WorkloadReference
+	workloadReference := state.Workload
 
 	var err error
 
 	loadWorkload := func() {
-		err = workloadReference.Load(ctx, clients.Client)
+		err = workloadReference.Reload(ctx, clients.Client)
 	}
 
 	if spinnerErr := spinner.New().Title("Loading workload").Action(loadWorkload).Run(); spinnerErr != nil {
@@ -82,7 +82,7 @@ func runPortForward(ctx context.Context, clients k8s.KubernetesClients, state *t
 		}
 	}
 
-	for _, pod := range workloadReference.GetPods() {
+	for _, pod := range workloadReference.ListKnownPods() {
 		for _, container := range pod.Pod.Spec.Containers {
 			for _, port := range container.Ports {
 				targets = append(targets, ContainerPortForwardTarget{

--- a/pkg/tui/list/workload/select.go
+++ b/pkg/tui/list/workload/select.go
@@ -58,7 +58,7 @@ func runSelectWorkload(ctx context.Context, clients k8s.KubernetesClients, state
 
 	var err error
 
-	var workloadReferences []workloads.WorkloadReference
+	var workloadReferences []workloads.Workload
 
 	loadReferences := func() {
 		workloadReferences, err = factory.ListObjects(ctx, clients.Client, state.WorkloadType, labelSelector, client.InNamespace(state.Namespace))
@@ -80,7 +80,7 @@ func runSelectWorkload(ctx context.Context, clients k8s.KubernetesClients, state
 
 	var data [][]string
 
-	dataMap := map[string]workloads.WorkloadReference{}
+	dataMap := map[string]workloads.Workload{}
 
 	for _, workloadReference := range workloadReferences {
 		data = append(data, []string{
@@ -102,9 +102,9 @@ func runSelectWorkload(ctx context.Context, clients k8s.KubernetesClients, state
 		return result, nil, fmt.Errorf("failed to select the workload: %w", err)
 	}
 	if result == tuicomponents.StepResultOk {
-		state.WorkloadReference = workloadReferences[selectedRow]
+		state.Workload = workloadReferences[selectedRow]
 	} else {
-		state.WorkloadReference = nil
+		state.Workload = nil
 	}
 
 	return result, runSelectWorkloadAction, nil

--- a/pkg/workloads/apply.go
+++ b/pkg/workloads/apply.go
@@ -249,39 +249,6 @@ func generateConfigMapManifest(files map[string]string, workload Workload, metaC
 	return nil, nil
 }
 
-//// generateWorkloadManifest prepares the main workload manifest
-//func generateWorkloadManifest(workloadTemplate []byte, templateContext WorkloadTemplateConfig, workload Workload) (client.Object, error) {
-//	parsedTemplate, err := template.New("main").Funcs(sprig.TxtFuncMap()).Parse(string(workloadTemplate))
-//	if err != nil {
-//		return nil, fmt.Errorf("failed to parse template: %w", err)
-//	}
-//
-//	var renderedYAML strings.Builder
-//	err = parsedTemplate.Execute(&renderedYAML, templateContext)
-//	if err != nil {
-//		return nil, fmt.Errorf("failed to render template: %w", err)
-//	}
-//
-//	scheme, err := k8s.GetScheme()
-//	if err != nil {
-//		return nil, fmt.Errorf("failed to fetch scheme: %w", err)
-//	}
-//
-//	decoder := serializer.NewCodecFactory(&scheme).UniversalDeserializer()
-//
-//	obj, _, err := decoder.Decode([]byte(renderedYAML.String()), nil, nil)
-//	if err != nil {
-//		return nil, fmt.Errorf("failed to decode manifest: %w", err)
-//	}
-//
-//	converted, ok := workload.ConvertObject(obj)
-//	if !ok {
-//		return nil, fmt.Errorf("failed to convert manifest, ensure it is of the correct type")
-//	}
-//
-//	return converted, nil
-//}
-
 // printResources prints each Kubernetes manifest in an array
 func printResources(s *runtime.Scheme, resources []client.Object) {
 	for _, resource_ := range resources {

--- a/pkg/workloads/factory/factory.go
+++ b/pkg/workloads/factory/factory.go
@@ -33,13 +33,13 @@ import (
 func GetWorkload(workloadType string) (workloads.Workload, error) {
 	switch workloadType {
 	case "rayjob":
-		return ray.Job{}, nil
+		return &ray.Job{}, nil
 	case "rayservice":
-		return ray.Deployment{}, nil
+		return &ray.Deployment{}, nil
 	case "job":
-		return jobs.Job{}, nil
+		return &jobs.Job{}, nil
 	case "deployment":
-		return deployments.Deployment{}, nil
+		return &deployments.Deployment{}, nil
 	default:
 		return nil, fmt.Errorf("unknown workload type: %s", workloadType)
 	}
@@ -63,8 +63,8 @@ func GetWorkloadAndObjectKey(workloadDescriptor string, namespace string) (workl
 	return workload, key, nil
 }
 
-func ListObjects(ctx context.Context, k8sClient client.Client, workloadType string, opts ...client.ListOption) ([]workloads.WorkloadReference, error) {
-	var workloadReferences []workloads.WorkloadReference
+func ListObjects(ctx context.Context, k8sClient client.Client, workloadType string, opts ...client.ListOption) ([]workloads.Workload, error) {
+	var workloadReferences []workloads.Workload
 
 	// TODO refactor
 	switch workloadType {
@@ -74,12 +74,7 @@ func ListObjects(ctx context.Context, k8sClient client.Client, workloadType stri
 			return nil, err
 		}
 		for _, rayJob := range rayJobList.Items {
-			workloadReferences = append(workloadReferences, &ray.JobReference{
-				RayJob: rayJob,
-				WorkloadReferenceBase: workloads.WorkloadReferenceBase{
-					WorkloadObject: &rayJob,
-				},
-			})
+			workloadReferences = append(workloadReferences, &ray.Job{RayJob: rayJob})
 		}
 	case "rayservice":
 		rayServiceList := &rayv1.RayServiceList{}
@@ -87,12 +82,7 @@ func ListObjects(ctx context.Context, k8sClient client.Client, workloadType stri
 			return nil, err
 		}
 		for _, rayService := range rayServiceList.Items {
-			workloadReferences = append(workloadReferences, &ray.ServiceReference{
-				RayService: rayService,
-				WorkloadReferenceBase: workloads.WorkloadReferenceBase{
-					WorkloadObject: &rayService,
-				},
-			})
+			workloadReferences = append(workloadReferences, &ray.Deployment{RayService: rayService})
 		}
 	case "job":
 		jobList := &batchv1.JobList{}
@@ -100,12 +90,7 @@ func ListObjects(ctx context.Context, k8sClient client.Client, workloadType stri
 			return nil, err
 		}
 		for _, job := range jobList.Items {
-			workloadReferences = append(workloadReferences, &jobs.JobReference{
-				Job: job,
-				WorkloadReferenceBase: workloads.WorkloadReferenceBase{
-					WorkloadObject: &job,
-				},
-			})
+			workloadReferences = append(workloadReferences, &jobs.Job{Job: job})
 		}
 	case "deployment":
 		deploymentList := &appsv1.DeploymentList{}
@@ -113,12 +98,7 @@ func ListObjects(ctx context.Context, k8sClient client.Client, workloadType stri
 			return nil, err
 		}
 		for _, deployment := range deploymentList.Items {
-			workloadReferences = append(workloadReferences, &deployments.DeploymentReference{
-				Deployment: deployment,
-				WorkloadReferenceBase: workloads.WorkloadReferenceBase{
-					WorkloadObject: &deployment,
-				},
-			})
+			workloadReferences = append(workloadReferences, &deployments.Deployment{Deployment: deployment})
 		}
 	default:
 		return nil, fmt.Errorf("unknown workload type: %s", workloadType)

--- a/pkg/workloads/job.go
+++ b/pkg/workloads/job.go
@@ -15,6 +15,7 @@
 package workloads
 
 import (
+	"context"
 	"fmt"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,7 +30,7 @@ type JobFlags struct {
 	Queue string
 }
 
-func CreateLocalQueueManifest(k8sClient client.Client, templateContext WorkloadTemplateConfig) (*kueuev1beta1.LocalQueue, error) {
+func CreateLocalClusterQueueManifest(ctx context.Context, k8sClient client.Client, templateContext WorkloadTemplateConfig) (*kueuev1beta1.LocalQueue, error) {
 	jobMeta, ok := templateContext.WorkloadMeta.(JobFlags)
 
 	if !ok {
@@ -37,7 +38,7 @@ func CreateLocalQueueManifest(k8sClient client.Client, templateContext WorkloadT
 	}
 
 	// Handle jobs local queue
-	localQueue, err := k8s.PrepareLocalQueue(jobMeta.Queue, templateContext.Meta.Namespace, k8sClient)
+	localQueue, err := k8s.PrepareLocalClusterQueue(ctx, jobMeta.Queue, templateContext.Meta.Namespace, k8sClient)
 	if err != nil {
 		return nil, fmt.Errorf("error preparing local cluster queue: %v", err)
 	}

--- a/pkg/workloads/workload.go
+++ b/pkg/workloads/workload.go
@@ -16,77 +16,130 @@ package workloads
 
 import (
 	"context"
+	"fmt"
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+
+	"github.com/silogen/kaiwo/pkg/k8s"
 
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Workload represents the workload as it is meant to be created
+// WorkloadBase is the base object that all workloads share
+type WorkloadBase struct{}
+
+func (wb WorkloadBase) GetName() string {
+	return wb.GetObject().GetName()
+}
+
+func (wb WorkloadBase) GetNamespace() string {
+	return wb.GetObject().GetNamespace()
+}
+
+func (wb WorkloadBase) GetKaiwoUser() string {
+	return wb.GetObject().GetLabels()[KaiwoUsernameLabel]
+}
+
+func (wb WorkloadBase) GetObject() client.Object {
+	panic("Method should be overridden")
+}
+
+func (wb WorkloadBase) GetServices(_ context.Context, _ client.Client) ([]corev1.Service, error) {
+	return []corev1.Service{}, nil
+}
+
+func (wb WorkloadBase) SetFromObject(_ client.Object) error {
+	panic("Method should be overridden")
+}
+
+func (wb WorkloadBase) SetFromTemplate(workloadTemplate []byte, templateContext WorkloadTemplateConfig) error {
+	parsedTemplate, err := template.New("main").Funcs(sprig.TxtFuncMap()).Parse(string(workloadTemplate))
+	if err != nil {
+		return fmt.Errorf("failed to parse template: %w", err)
+	}
+
+	var renderedYAML strings.Builder
+	err = parsedTemplate.Execute(&renderedYAML, templateContext)
+	if err != nil {
+		return fmt.Errorf("failed to render template: %w", err)
+	}
+
+	scheme, err := k8s.GetScheme()
+	if err != nil {
+		return fmt.Errorf("failed to fetch scheme: %w", err)
+	}
+
+	decoder := serializer.NewCodecFactory(&scheme).UniversalDeserializer()
+
+	obj, _, err := decoder.Decode([]byte(renderedYAML.String()), nil, nil)
+	if err != nil {
+		return fmt.Errorf("failed to decode manifest: %w", err)
+	}
+
+	converted, ok := obj.(client.Object)
+
+	if !ok {
+		return fmt.Errorf("failed to decode manifest")
+	}
+
+	return wb.SetFromObject(converted)
+}
+
+// LoadFromObjectKey loads the workload from Kubernetes based on the object key (name and namespace)
+func (wb WorkloadBase) LoadFromObjectKey(ctx context.Context, k8sClient client.Client, key client.ObjectKey) error {
+	base := wb.GetObject().DeepCopyObject().(client.Object)
+	err := k8sClient.Get(ctx, key, base)
+	if err != nil {
+		return err
+	}
+	return wb.SetFromObject(base)
+}
+
+func (wb WorkloadBase) Reload(ctx context.Context, k8sClient client.Client) error {
+	return wb.LoadFromObjectKey(ctx, k8sClient, client.ObjectKey{
+		Namespace: wb.GetNamespace(),
+		Name:      wb.GetName(),
+	})
+}
+
+func (wb WorkloadBase) GenerateAdditionalResourceManifests(_ context.Context, _ client.Client, _ WorkloadTemplateConfig) ([]client.Object, error) {
+	return []client.Object{}, nil
+}
+
+// Workload represents the generic workload object
 type Workload interface {
 	// GenerateTemplateContext creates the workload-specific context that can be passed to the template
 	GenerateTemplateContext(ExecFlags) (any, error)
 
-	//// GenerateName provides a name that can be used to describe the workload
-	//GenerateName() string
-
 	// DefaultTemplate returns a default template to use for this workload
 	DefaultTemplate() ([]byte, error)
 
-	ConvertObject(object runtime.Object) (client.Object, bool)
+	SetFromTemplate([]byte, WorkloadTemplateConfig) error
 
 	// IgnoreFiles lists the files that should be ignored in the ConfigMap
 	IgnoreFiles() []string
 
-	// GetPods returns a list of pods that are associated with this workload
-	GetPods() ([]corev1.Pod, error)
+	// GenerateAdditionalResourceManifests returns additional manifests that are required for creating the workload
+	GenerateAdditionalResourceManifests(context.Context, client.Client, WorkloadTemplateConfig) ([]client.Object, error)
 
-	// GetServices returns a list of services that are associated with this workload
-	GetServices() ([]corev1.Service, error)
+	// Reload loads the current state from Kubernetes again
+	Reload(context.Context, client.Client) error
 
-	// GenerateAdditionalResourceManifests allow
-	GenerateAdditionalResourceManifests(k8sClient client.Client, templateContext WorkloadTemplateConfig) ([]runtime.Object, error)
+	// LoadFromObjectKey loads the state from Kubernetes given an object key (name and namespace)
+	LoadFromObjectKey(context.Context, client.Client, client.ObjectKey) error
 
-	// BuildReference builds the workload reference from this workload
-	BuildReference(ctx context.Context, k8sClient client.Client, key client.ObjectKey) (WorkloadReference, error)
-}
+	// ResolveStructure loads the current expanded structure from k8s to make it easier to interact with the workload
+	ResolveStructure(ctx context.Context, k8sClient client.Client) error
 
-type WorkloadPod struct {
-	Pod          corev1.Pod
-	LogicalGroup string
-}
+	// ListKnownPods returns the pods that the reference is currently aware of
+	ListKnownPods() []WorkloadPod
 
-type WorkloadReferenceBase struct {
-	WorkloadObject client.Object
-}
-
-func (workloadReferenceBase WorkloadReferenceBase) GetName() string {
-	return workloadReferenceBase.WorkloadObject.GetName()
-}
-
-func (workloadReferenceBase WorkloadReferenceBase) GetNamespace() string {
-	return workloadReferenceBase.WorkloadObject.GetNamespace()
-}
-
-func (workloadReferenceBase WorkloadReferenceBase) GetKaiwoUser() string {
-	return workloadReferenceBase.WorkloadObject.GetLabels()[KaiwoUsernameLabel]
-}
-
-func (workloadReferenceBase WorkloadReferenceBase) GetObject() client.Object {
-	return workloadReferenceBase.WorkloadObject
-}
-
-func (workloadReferenceBase WorkloadReferenceBase) GetServices(_ context.Context, _ client.Client) ([]corev1.Service, error) {
-	return []corev1.Service{}, nil
-}
-
-type WorkloadReference interface {
-	// Load loads the current state from k8s
-	Load(ctx context.Context, k8sClient client.Client) error
-
-	// GetPods returns the pods that the reference is currently aware of
-	GetPods() []WorkloadPod
-
+	// GetStatus returns a human-readable status of the workload
 	GetStatus() string
 
 	GetName() string
@@ -98,4 +151,9 @@ type WorkloadReference interface {
 	GetKaiwoUser() string
 
 	GetServices(ctx context.Context, k8sClient client.Client) ([]corev1.Service, error)
+}
+
+type WorkloadPod struct {
+	Pod          corev1.Pod
+	LogicalGroup string
 }


### PR DESCRIPTION
# Description

The code was getting hard to understand and manage, so Workload and WorkloadReference interfaces are being merged. Additionally templates are defined primarily in code now, in order to reduce duplication and sources of errors. Each podspec gets the default values of volumes, env vars, security contexts, etc. Templates can still be overridden by providing a template file like up until now though.

- [x] Merge workload and workload reference
- [ ] Move templates to code

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [ ] Existing workload examples run to completion after my changes (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes