### PR TITLE
Add extra template function toYaml, define txtfuncmap in separate file

### DIFF
--- a/pkg/workloads/apply.go
+++ b/pkg/workloads/apply.go
@@ -25,7 +25,6 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/Masterminds/sprig/v3"
 	"github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -256,7 +255,7 @@ func generateConfigMapManifest(files map[string]string, workload Workload, metaC
 
 // generateWorkloadManifest prepares the main workload manifest
 func generateWorkloadManifest(workloadTemplate []byte, templateContext WorkloadTemplateConfig, workload Workload) (client.Object, error) {
-	parsedTemplate, err := template.New("main").Funcs(sprig.TxtFuncMap()).Parse(string(workloadTemplate))
+	parsedTemplate, err := template.New("main").Funcs(GetTemplateFuncMap()).Parse(string(workloadTemplate))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse template: %w", err)
 	}

--- a/pkg/workloads/template_funcs.go
+++ b/pkg/workloads/template_funcs.go
@@ -1,0 +1,41 @@
+// Copyright 2025 Advanced Micro Devices, Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package workloads
+
+import (
+	"strings"
+	"text/template"
+
+	"github.com/Masterminds/sprig/v3"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/yaml"
+)
+
+// This defines the extra functions that are usable in kaiwo template files
+// in addition to the go template defaults.
+func GetTemplateFuncMap() template.FuncMap {
+	funcMap := sprig.TxtFuncMap()
+	funcMap["toYaml"] = toYaml
+	return funcMap
+}
+
+func toYaml(v interface{}) string {
+	data, err := yaml.Marshal(v)
+	if err != nil {
+		logrus.Errorf("Failed to marshal object to YAML: %v", err)
+		return ""
+	}
+	return strings.TrimSuffix(string(data), "\n")
+}


### PR DESCRIPTION
# Description

To aid templating, we may need some more functions besides those in go template natively and in sprig. One key addition for me is a toYaml filter, this essentially allows YAML pass-through, as in letting us give YAML as a custom-config value and have it render as YAML in the output.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [ ] Existing workload examples run to completion after my changes (if applicable)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes