### PR TITLE
fix webhook operations

### DIFF
--- a/config/webhook/webhooks.yaml
+++ b/config/webhook/webhooks.yaml
@@ -13,7 +13,7 @@ webhooks:
     rules:
       - apiGroups: ["batch"]
         apiVersions: ["v1"]
-        operations: ["CREATE", "UPDATE"]
+        operations: ["CREATE"]
         resources: ["jobs"]
     failurePolicy: Fail
     sideEffects: None

--- a/test/chainsaw/configs/ci.yaml
+++ b/test/chainsaw/configs/ci.yaml
@@ -11,6 +11,4 @@ spec:
     error: 60s
     exec: 10s
   execution:
-    parallel: 1
-# test/chainsaw/values/sensitive/values.yaml
-# test/chainsaw/values/sensitive/values.yaml
+    parallel: 3

--- a/test/chainsaw/configs/ci.yaml
+++ b/test/chainsaw/configs/ci.yaml
@@ -12,3 +12,5 @@ spec:
     exec: 10s
   execution:
     parallel: 1
+# test/chainsaw/values/sensitive/values.yaml
+# test/chainsaw/values/sensitive/values.yaml


### PR DESCRIPTION
# Description

The webhook mutation endpoint was being called on both create and update, but only create is needed. This caused issues with concurrent operations.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [ ] Existing workload examples run to completion after my changes (if applicable)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes