### PR TITLE
add kaiwo namespace to default kaiwoqueueconfig

### DIFF
--- a/internal/controller/utils/kueue.go
+++ b/internal/controller/utils/kueue.go
@@ -326,7 +326,8 @@ func CreateClusterQueue(nodePoolResources map[string]kueuev1beta1.FlavorQuotas, 
 
 	// Create ClusterQueue
 	return v1alpha1.ClusterQueue{
-		Name: name,
+		Name:       name,
+		Namespaces: []string{"kaiwo"},
 		Spec: kueuev1beta1.ClusterQueueSpec{
 			NamespaceSelector: &metav1.LabelSelector{},
 			ResourceGroups:    resourceGroups,


### PR DESCRIPTION
# Description

Added kaiwo namespace to default kaiwo queue config's cluster queue

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes