### PR TITLE
CLI helpers for Node resources and Queue statues

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -5,4 +5,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: ghcr.io/silogen/kaiwo-operator
-  newTag: v.0.1
+  newTag: v-e2e

--- a/docs/docs/scientist/cli.md
+++ b/docs/docs/scientist/cli.md
@@ -104,6 +104,7 @@ You can use the Kaiwo CLI to
 * `kaiwo logs`: Fetch workload logs
 * `kaiwo monitor`: Monitor (GPU) workloads
 * `kaiwo exec`: Execute arbitrary commands inside the workload containers
+* `kaiwo stats`: Check the status of your cluster
 
 For a list of full functionality run `kaiwo --help`, or for a specific command, `kaiwo <command> --help`.
 
@@ -188,3 +189,16 @@ The following flags are supported:
 * `--command` to specify the command to execute
 * `-n / --namespace` to specify the namespace
 
+### Checking cluster status
+
+You can check the current resource availability (including GPUs) of your cluster by running: 
+
+```
+kaiwo stats nodes
+```
+
+You can check the current queue statuses for GPU jobs by running:
+
+```
+kaiwo stats queues
+```

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/charmbracelet/huh v0.6.0
 	github.com/charmbracelet/huh/spinner v0.0.0-20250324195341-f31a8c95fe4f
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/olekukonko/tablewriter v0.0.5
 	github.com/onsi/ginkgo/v2 v2.23.0
 	github.com/onsi/gomega v1.36.2
 	github.com/project-codeflare/appwrapper v1.1.0

--- a/go.sum
+++ b/go.sum
@@ -130,6 +130,7 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/mattn/go-localereader v0.0.1 h1:ygSAOl7ZXTx4RdPYinUpg6W99U8jWvWi9Ye2JC/oIi4=
 github.com/mattn/go-localereader v0.0.1/go.mod h1:8fBrzywKY7BI3czFoHkuzRoWE9C+EiG4R1k4Cjx5p88=
+github.com/mattn/go-runewidth v0.0.9/go.mod h1:H031xJmbD/WCDINGzjvQ9THkh0rPKHF+m2gUSrubnMI=
 github.com/mattn/go-runewidth v0.0.16 h1:E5ScNMtiwvlvB5paMFdw9p4kSQzbXFikJ5SQO6TULQc=
 github.com/mattn/go-runewidth v0.0.16/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
 github.com/mitchellh/hashstructure/v2 v2.0.2 h1:vGKWl0YJqUNxE8d+h8f6NJLcCJrgbhC4NcD46KavDd4=
@@ -151,6 +152,8 @@ github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 h1:C3w9PqII01/Oq
 github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822/go.mod h1:+n7T8mK8HuQTcFwEeznm/DIxMOiR9yIdICNftLE1DvQ=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f h1:y5//uYreIhSUg3J1GEMiLbxo1LJaP8RfCpH6pymGZus=
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
+github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
+github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
 github.com/onsi/ginkgo/v2 v2.23.0 h1:FA1xjp8ieYDzlgS5ABTpdUDB7wtngggONc8a7ku2NqQ=
 github.com/onsi/ginkgo/v2 v2.23.0/go.mod h1:zXTP6xIp3U8aVuXN8ENK9IXRaTjFnpVB9mGmaSRvxnM=
 github.com/onsi/gomega v1.36.2 h1:koNYke6TVk6ZmnyHrCXba/T/MoLBXFjeC1PtvYgw0A8=
@@ -164,12 +167,8 @@ github.com/project-codeflare/appwrapper v1.1.0 h1:0YDti8qqsnML/YCofOSQ6az++6dhQK
 github.com/project-codeflare/appwrapper v1.1.0/go.mod h1:Y9XqesMiT0OsHsicHYvC6/Xoj0EMYgJYUo3Vob6JvKo=
 github.com/prometheus/client_golang v1.21.1 h1:DOvXXTqVzvkIewV/CDPFdejpMCGeMcbGCQ8YOmu+Ibk=
 github.com/prometheus/client_golang v1.21.1/go.mod h1:U9NM32ykUErtVBxdvD3zfi+EuFkkaBvMb09mIfe0Zgg=
-github.com/prometheus/client_model v0.6.1 h1:ZKSh/rekM+n3CeS952MLRAdFwIKqeY8b62p8ais2e9E=
-github.com/prometheus/client_model v0.6.1/go.mod h1:OrxVMOVHjw3lKMa8+x6HeMGkHMQyHDk9E3jmP2AmGiY=
 github.com/prometheus/client_model v0.6.2 h1:oBsgwpGs7iVziMvrGhE53c/GrLUsZdHnqNwqPLxwZyk=
 github.com/prometheus/client_model v0.6.2/go.mod h1:y3m2F6Gdpfy6Ut/GBsUqTWZqCUvMVzSfMLjcu6wAwpE=
-github.com/prometheus/common v0.62.0 h1:xasJaQlnWAeyHdUBeGjXmutelfJHWMRr+Fg4QszZ2Io=
-github.com/prometheus/common v0.62.0/go.mod h1:vyBcEuLSvWos9B1+CyL7JZ2up+uFzXhkqml0W5zIY1I=
 github.com/prometheus/common v0.63.0 h1:YR/EIY1o3mEFP/kZCD7iDMnLPlGyuU2Gb3HIcXnA98k=
 github.com/prometheus/common v0.63.0/go.mod h1:VVFF/fBIoToEnWRVkYoXEkq3R3paCoxG9PXP74SnV18=
 github.com/prometheus/procfs v0.15.1 h1:YagwOFzUgYfKKHX6Dr+sHT7km/hxC76UB0learggepc=
@@ -282,10 +281,6 @@ google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7 h1:
 google.golang.org/genproto/googleapis/rpc v0.0.0-20240826202546-f6391c0de4c7/go.mod h1:UqMtugtsSgubUsoxbuAoiCXvqvErP7Gf0so0mK9tHxU=
 google.golang.org/grpc v1.65.0 h1:bs/cUb4lp1G5iImFFd3u5ixQzweKizoZJAwBNLR42lc=
 google.golang.org/grpc v1.65.0/go.mod h1:WgYC2ypjlB0EiQi6wdKixMqukr6lBc0Vo+oOgjrM5ZQ=
-google.golang.org/protobuf v1.36.4 h1:6A3ZDJHn/eNqc1i+IdefRzy/9PokBTPvcqMySR7NNIM=
-google.golang.org/protobuf v1.36.4/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
-google.golang.org/protobuf v1.36.5 h1:tPhr+woSbjfYvY6/GPufUoYizxw1cF/yFoxJ2fmpwlM=
-google.golang.org/protobuf v1.36.5/go.mod h1:9fA7Ob0pmnwhb644+1+CVWFRbNajQ6iRojtC/QF5bRE=
 google.golang.org/protobuf v1.36.6 h1:z1NpPI8ku2WgiWnf+t9wTPsn6eP1L7ksHUlkfLvd9xY=
 google.golang.org/protobuf v1.36.6/go.mod h1:jduwjTPXsFjZGTmRluh+L6NjiWu7pchiJ2/5YcXBHnY=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=

--- a/pkg/cli/main.go
+++ b/pkg/cli/main.go
@@ -86,6 +86,7 @@ func RunCli() {
 		BuildListCmd(),
 		BuildMonitorCmd("monitor", cliutils.DefaultMonitorCommand),
 		BuildExecCommand(),
+		BuildStatsCmd(),
 	)
 
 	if err := rootCmd.Execute(); err != nil {

--- a/pkg/cli/stats.go
+++ b/pkg/cli/stats.go
@@ -22,8 +22,6 @@ import (
 	"reflect"
 	"strings"
 
-	workloadutils "github.com/silogen/kaiwo/pkg/workloads/utils"
-
 	"k8s.io/apimachinery/pkg/api/meta"
 
 	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
@@ -60,7 +58,7 @@ func BuildStatsCmd() *cobra.Command {
 	return statsCmd
 }
 
-var gpuResourceName = v1.ResourceName(workloadutils.DefaultGpuResourceKey)
+var gpuResourceName = v1.ResourceName("amd.com/gpu")
 
 func fetchWithSpinner(ctx context.Context, k8sClient client.Client, list client.ObjectList) error {
 	t := reflect.TypeOf(list)

--- a/pkg/cli/stats.go
+++ b/pkg/cli/stats.go
@@ -1,0 +1,338 @@
+// Copyright 2025 Advanced Micro Devices, Inc.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"os"
+	"reflect"
+	"strings"
+
+	workloadutils "github.com/silogen/kaiwo/pkg/workloads/utils"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+
+	"sigs.k8s.io/kueue/apis/kueue/v1beta1"
+
+	"github.com/olekukonko/tablewriter"
+
+	"k8s.io/apimachinery/pkg/api/resource"
+
+	"github.com/charmbracelet/huh/spinner"
+	"github.com/spf13/cobra"
+	v1 "k8s.io/api/core/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/silogen/kaiwo/pkg/k8s"
+)
+
+func BuildStatsCmd() *cobra.Command {
+	statsCmd := &cobra.Command{
+		Use: "stats",
+	}
+
+	nodesStatsCmd := &cobra.Command{
+		Use:  "nodes",
+		RunE: runNodesStatsCmd,
+	}
+	statsCmd.AddCommand(nodesStatsCmd)
+
+	queueStatsCmd := &cobra.Command{
+		Use:  "queues",
+		RunE: runQueueStatsCmd,
+	}
+	statsCmd.AddCommand(queueStatsCmd)
+
+	return statsCmd
+}
+
+var gpuResourceName = v1.ResourceName(workloadutils.DefaultGpuResourceKey)
+
+func fetchWithSpinner(ctx context.Context, k8sClient client.Client, list client.ObjectList) error {
+	t := reflect.TypeOf(list)
+	if t.Kind() == reflect.Ptr {
+		t = t.Elem()
+	}
+	base := strings.TrimSuffix(t.Name(), "List")
+	resourceName := strings.ToLower(base) + "s"
+
+	var err error
+	if spinErr := spinner.New().
+		Title(fmt.Sprintf("Fetching %s", resourceName)).
+		Action(func() { err = k8sClient.List(ctx, list, &client.ListOptions{}) }).
+		Run(); spinErr != nil {
+		panic(spinErr)
+	}
+	if err != nil {
+		return fmt.Errorf("failed to list %s: %w", resourceName, err)
+	}
+	return nil
+}
+
+func runNodesStatsCmd(_ *cobra.Command, _ []string) error {
+	clients, err := k8s.GetKubernetesClients()
+	if err != nil {
+		return fmt.Errorf("failed to get k8s clients: %w", err)
+	}
+
+	ctx := context.Background()
+
+	nodeList := v1.NodeList{}
+
+	allocatable := map[string]v1.ResourceList{}
+
+	if err := fetchWithSpinner(ctx, clients.Client, &nodeList); err != nil {
+		return fmt.Errorf("failed to fetch nodes: %w", err)
+	}
+
+	for _, node := range nodeList.Items {
+		allocatable[node.Name] = node.Status.Allocatable
+	}
+
+	podList := v1.PodList{}
+	if err := fetchWithSpinner(ctx, clients.Client, &podList); err != nil {
+		return fmt.Errorf("failed to fetch pods: %w", err)
+	}
+
+	requested := map[string]v1.ResourceList{}
+	podCount := make(map[string]int)
+
+	for _, pod := range podList.Items {
+		if pod.Spec.NodeName == "" {
+			continue
+		}
+		podCount[pod.Spec.NodeName]++
+
+		nodeName := pod.Spec.NodeName
+		if _, ok := requested[nodeName]; !ok {
+			requested[nodeName] = v1.ResourceList{}
+		}
+		for _, container := range pod.Spec.Containers {
+			for resourceType, resourceAmount := range container.Resources.Requests {
+				if _, ok := requested[nodeName][resourceType]; !ok {
+					requested[nodeName][resourceType] = resource.Quantity{}
+				}
+				currentQuantity := requested[nodeName][resourceType]
+				currentQuantity.Add(resourceAmount)
+				requested[nodeName][resourceType] = currentQuantity
+			}
+		}
+	}
+
+	nodesTable := tablewriter.NewWriter(os.Stdout)
+	nodesTable.SetHeader([]string{"NODE", "GPU (used/alloc %)", "CPU (used/alloc %)", "MEM (used/alloc %)", "PODS (used/alloc %)"})
+	nodesTable.SetAutoWrapText(false)
+	nodesTable.SetAlignment(tablewriter.ALIGN_LEFT)
+	nodesTable.SetCaption(true, fmt.Sprintf("GPU requests are looked up by the resource name '%s'", gpuResourceName))
+
+	const bytesInGi = 1024 * 1024 * 1024
+
+	for _, node := range nodeList.Items {
+		name := node.Name
+
+		// GPU
+		allocGPU := allocatable[name][gpuResourceName]
+		usedGPU := requested[name][gpuResourceName]
+		gpuPct := float64(usedGPU.Value()) / float64(allocGPU.Value()) * 100
+		if math.IsNaN(gpuPct) {
+			gpuPct = 0
+		}
+		gpuCell := fmt.Sprintf("%d/%d (%.1f%%)", int(usedGPU.Value()), allocGPU.Value(), gpuPct)
+
+		// CPU
+		allocCPU := allocatable[name][v1.ResourceCPU]
+		usedCPU := requested[name][v1.ResourceCPU]
+		usedCores := float64(usedCPU.MilliValue() / 1000)
+		allocCores := float64(allocCPU.MilliValue() / 1000)
+		cpuPct := usedCores / allocCores * 100
+		cpuCell := fmt.Sprintf("%.1f/%.1f (%.1f%%)", usedCores, allocCores, cpuPct)
+
+		// MEM
+		allocMemB := allocatable[name][v1.ResourceMemory]
+		usedMemB := requested[name][v1.ResourceMemory]
+		usedGi := float64(usedMemB.Value()) / bytesInGi
+		allocGi := float64(allocMemB.Value()) / bytesInGi
+		memPct := usedGi / allocGi * 100
+		memCell := fmt.Sprintf("%.1fGi/%.1fGi (%.1f%%)", usedGi, allocGi, memPct)
+
+		// PODS
+		allocPods := allocatable[name][v1.ResourcePods]
+		allocPodsV := allocPods.Value()
+		usedPods := int64(podCount[name])
+		podsPct := float64(usedPods) / float64(allocPodsV) * 100
+		podCell := fmt.Sprintf("%d/%d (%.1f%%)", usedPods, allocPodsV, podsPct)
+
+		nodesTable.Append([]string{name, gpuCell, cpuCell, memCell, podCell})
+	}
+
+	nodesTable.Render()
+
+	return nil
+}
+
+func runQueueStatsCmd(cmd *cobra.Command, args []string) error {
+	clients, err := k8s.GetKubernetesClients()
+	if err != nil {
+		return fmt.Errorf("failed to get k8s clients: %w", err)
+	}
+
+	ctx := context.Background()
+
+	clusterQueueList := v1beta1.ClusterQueueList{}
+	if err := fetchWithSpinner(ctx, clients.Client, &clusterQueueList); err != nil {
+		return fmt.Errorf("failed to fetch cluster queues: %w", err)
+	}
+
+	localQueueList := v1beta1.LocalQueueList{}
+	if err := fetchWithSpinner(ctx, clients.Client, &localQueueList); err != nil {
+		return fmt.Errorf("failed to fetch local queues: %w", err)
+	}
+
+	workloadList := v1beta1.WorkloadList{}
+	if err := fetchWithSpinner(ctx, clients.Client, &workloadList); err != nil {
+		return fmt.Errorf("failed to fetch workloads: %w", err)
+	}
+
+	// 3) Prepare data structures
+	// map[clusterQueueName] -> []LocalQueue
+	localQueuesByCluster := make(map[string][]v1beta1.LocalQueue, len(clusterQueueList.Items))
+
+	// GPU counts at cluster level
+	clusterAdmittedGPU := make(map[string]int, len(clusterQueueList.Items))
+	clusterPendingGPU := make(map[string]int, len(clusterQueueList.Items))
+
+	// GPU counts at local-queue level: map[clusterQueueName] -> map[localQueueName] -> count
+	localAdmittedGPU := make(map[string]map[string]int, len(clusterQueueList.Items))
+	localPendingGPU := make(map[string]map[string]int, len(clusterQueueList.Items))
+
+	// Reverse lookup: map[namespace] -> map[localQueueName] -> clusterQueueName
+	localQueueToCluster := make(map[string]map[string]string, len(localQueueList.Items))
+
+	// 3a) Initialize cluster-level entries
+	for _, clusterQueue := range clusterQueueList.Items {
+		localQueuesByCluster[clusterQueue.Name] = nil
+		clusterAdmittedGPU[clusterQueue.Name] = 0
+		clusterPendingGPU[clusterQueue.Name] = 0
+		localAdmittedGPU[clusterQueue.Name] = make(map[string]int)
+		localPendingGPU[clusterQueue.Name] = make(map[string]int)
+	}
+
+	// 3b) Initialize local-level entries and build reverse lookup
+	for _, localQueue := range localQueueList.Items {
+		// Ensure the namespace map exists
+		if _, ok := localQueueToCluster[localQueue.Namespace]; !ok {
+			localQueueToCluster[localQueue.Namespace] = make(map[string]string)
+		}
+		clusterName := string(localQueue.Spec.ClusterQueue)
+		// Map this LocalQueue to its ClusterQueue
+		localQueueToCluster[localQueue.Namespace][localQueue.Name] = clusterName
+
+		// Append the LocalQueue under its ClusterQueue
+		localQueuesByCluster[clusterName] = append(localQueuesByCluster[clusterName], localQueue)
+
+		// Zero out our GPU counters at the local level
+		localAdmittedGPU[clusterName][localQueue.Name] = 0
+		localPendingGPU[clusterName][localQueue.Name] = 0
+	}
+
+	// 4) Filter for GPU-requesting workloads
+	var gpuWorkloads []v1beta1.Workload
+	for _, workload := range workloadList.Items {
+		if condition := meta.FindStatusCondition(workload.Status.Conditions, v1beta1.WorkloadFinished); condition != nil {
+			continue
+		}
+		requestsGpu := false
+
+		for _, podSet := range workload.Spec.PodSets {
+			// check each container in the PodTemplate
+			for _, container := range podSet.Template.Spec.Containers {
+				if qty, ok := container.Resources.Requests[gpuResourceName]; ok && qty.Value() > 0 {
+					requestsGpu = true
+					break
+				}
+			}
+			if requestsGpu {
+				break
+			}
+			for _, initContainer := range podSet.Template.Spec.InitContainers {
+				if qty, ok := initContainer.Resources.Requests[gpuResourceName]; ok && qty.Value() > 0 {
+					requestsGpu = true
+					break
+				}
+			}
+			if requestsGpu {
+				break
+			}
+		}
+
+		if requestsGpu {
+			gpuWorkloads = append(gpuWorkloads, workload)
+		}
+	}
+
+	// 5) Count admitted vs pending for each GPU-requesting workload
+	for _, workload := range gpuWorkloads {
+		namespace := workload.Namespace
+		localQueueName := workload.Spec.QueueName
+
+		// Find the ClusterQueue for this LocalQueue
+		clusterQueueName := "<unknown>"
+		if m, ok := localQueueToCluster[namespace]; ok {
+			if cqName, ok2 := m[localQueueName]; ok2 {
+				clusterQueueName = cqName
+			}
+		}
+
+		if workload.Status.Admission != nil {
+			clusterAdmittedGPU[clusterQueueName]++
+			localAdmittedGPU[clusterQueueName][localQueueName]++
+		} else {
+			clusterPendingGPU[clusterQueueName]++
+			localPendingGPU[clusterQueueName][localQueueName]++
+		}
+	}
+
+	// 6) Render results in a table
+	table := tablewriter.NewWriter(os.Stdout)
+	table.SetHeader([]string{"Cluster queue", "Local queue", "Admitted", "Pending"})
+	table.SetAutoWrapText(false)
+	table.SetAlignment(tablewriter.ALIGN_LEFT)
+	table.SetCaption(true, fmt.Sprintf("Only workloads that include requests to '%s' are included", gpuResourceName))
+
+	for _, clusterQueue := range clusterQueueList.Items {
+		// Cluster-level totals
+		table.Append([]string{
+			clusterQueue.Name,
+			"[TOTAL]",
+			fmt.Sprintf("%d", clusterAdmittedGPU[clusterQueue.Name]),
+			fmt.Sprintf("%d", clusterPendingGPU[clusterQueue.Name]),
+		})
+
+		// Local-level breakdown
+		for _, localQueue := range localQueuesByCluster[clusterQueue.Name] {
+			table.Append([]string{
+				clusterQueue.Name,
+				localQueue.Name,
+				fmt.Sprintf("%d", localAdmittedGPU[clusterQueue.Name][localQueue.Name]),
+				fmt.Sprintf("%d", localPendingGPU[clusterQueue.Name][localQueue.Name]),
+			})
+		}
+	}
+
+	table.Render()
+	return nil
+}


### PR DESCRIPTION
# Description

This PR adds two new commands to the CLI to show node resource usage and Kueue queue statuses for GPU workloads.

Fixes #100

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes