### PR TITLE
update to latest aim for tests, disable KServe downloading to avoid double downloads

### DIFF
--- a/internal/controller/aim/aimmodelcache_controller.go
+++ b/internal/controller/aim/aimmodelcache_controller.go
@@ -109,7 +109,6 @@ func (r *AIMModelCacheReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		},
 		FinalizeFn: nil,
 	})
-
 }
 
 // observation holds read-only snapshot of dependent resources and derived flags
@@ -249,7 +248,7 @@ func (r *AIMModelCacheReconciler) projectStatus(_ context.Context, mc *aimv1alph
 	status := mc.Status
 	var conditions []metav1.Condition
 
-	//Report any outstanding errors to report from previous controller actions
+	// Report any outstanding errors to report from previous controller actions
 	if errs.HasError() {
 
 		if errs.ObserveErr != nil {
@@ -277,7 +276,7 @@ func (r *AIMModelCacheReconciler) projectStatus(_ context.Context, mc *aimv1alph
 		return nil
 	}
 
-	//Check dependencies (pvc & job)
+	// Check dependencies (pvc & job)
 	mc.Status.PersistentVolumeClaim = r.pvcName(mc)
 	mc.Status.ObservedGeneration = mc.GetGeneration()
 
@@ -294,8 +293,8 @@ func (r *AIMModelCacheReconciler) projectStatus(_ context.Context, mc *aimv1alph
 	}
 	mc.Status.Status = r.determineOverallStatus(stateFlags, *ob)
 
-	//fmt.Printf("%v\n", newStatus)
-	//r.Recorder
+	// fmt.Printf("%v\n", newStatus)
+	// r.Recorder
 
 	return nil
 }

--- a/internal/controller/aim/shared/kserve.go
+++ b/internal/controller/aim/shared/kserve.go
@@ -142,6 +142,10 @@ func buildServingRuntimeSpec(template aimstate.TemplateState) servingv1alpha1.Se
 	}
 
 	return servingv1alpha1.ServingRuntimeSpec{
+		// The AIM containers handle downloading themselves
+		StorageHelper: &servingv1alpha1.StorageHelper{
+			Disabled: true,
+		},
 		SupportedModelFormats: []servingv1alpha1.SupportedModelFormat{
 			{
 				Name:    "aim",
@@ -261,10 +265,6 @@ func BuildInferenceService(serviceState aimstate.ServiceState, ownerRef metav1.O
 	if serviceState.Replicas != nil {
 		inferenceService.Spec.Predictor.MinReplicas = serviceState.Replicas
 		inferenceService.Spec.Predictor.MaxReplicas = *serviceState.Replicas
-	}
-
-	if serviceState.ModelSource != nil && serviceState.ModelSource.SourceURI != "" {
-		inferenceService.Spec.Predictor.Model.StorageURI = baseutils.Pointer(serviceState.ModelSource.SourceURI)
 	}
 
 	return inferenceService

--- a/test/chainsaw/tests/aim/aim-image-prepuller.yaml
+++ b/test/chainsaw/tests/aim/aim-image-prepuller.yaml
@@ -25,7 +25,7 @@ spec:
       - name: ghcr-pull-secret
       initContainers:
       - name: pull-ray-test
-        image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+        image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
         command: ["sh", "-c", "echo warmed"]
       containers:
       - name: hold

--- a/test/chainsaw/tests/aim/service/_shared/default-cluster-image.yaml
+++ b/test/chainsaw/tests/aim/service/_shared/default-cluster-image.yaml
@@ -3,7 +3,7 @@ kind: AIMClusterImage
 metadata:
   name: default-testing-llama-3-8b
 spec:
-  image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+  image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
   defaultServiceTemplate: default-testing-llama-3-8b
   resources:
     limits:

--- a/test/chainsaw/tests/aim/service/negative/routing-gateway-not-exists/cluster-image.yaml
+++ b/test/chainsaw/tests/aim/service/negative/routing-gateway-not-exists/cluster-image.yaml
@@ -3,7 +3,7 @@ kind: AIMClusterImage
 metadata:
   name: llama-3-8b-routing-no-gateway
 spec:
-  image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+  image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
   defaultServiceTemplate: llama-3-8b-latency-routing-no-gateway
   resources:
     limits:

--- a/test/chainsaw/tests/aim/service/positive/resources-image-fallback/cluster-image.yaml
+++ b/test/chainsaw/tests/aim/service/positive/resources-image-fallback/cluster-image.yaml
@@ -3,7 +3,7 @@ kind: AIMClusterImage
 metadata:
   name: image-fallback
 spec:
-  image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+  image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
   defaultServiceTemplate: image-fallback-template
   resources:
     limits:

--- a/test/chainsaw/tests/aim/service/positive/resources-service-override/cluster-image.yaml
+++ b/test/chainsaw/tests/aim/service/positive/resources-service-override/cluster-image.yaml
@@ -3,7 +3,7 @@ kind: AIMClusterImage
 metadata:
   name: service-override-image
 spec:
-  image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+  image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
   defaultServiceTemplate: service-override-template
   resources:
     limits:

--- a/test/chainsaw/tests/aim/service/positive/resources-template-override/cluster-image.yaml
+++ b/test/chainsaw/tests/aim/service/positive/resources-template-override/cluster-image.yaml
@@ -3,7 +3,7 @@ kind: AIMClusterImage
 metadata:
   name: template-override-image
 spec:
-  image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+  image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
   defaultServiceTemplate: template-override-template
   resources:
     limits:

--- a/test/chainsaw/tests/aim/templates/cluster-template-with-image/cluster-image.yaml
+++ b/test/chainsaw/tests/aim/templates/cluster-template-with-image/cluster-image.yaml
@@ -3,7 +3,7 @@ kind: AIMClusterImage
 metadata:
   name: llama-3-8b-cluster-with-image
 spec:
-  image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+  image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
   defaultServiceTemplate: llama-3-8b-latency-with-image
   resources:
     limits:

--- a/test/chainsaw/tests/aim/templates/discovery-results-cluster/chainsaw-test.yaml
+++ b/test/chainsaw/tests/aim/templates/discovery-results-cluster/chainsaw-test.yaml
@@ -76,6 +76,6 @@ spec:
             name: llama-3-8b-latency-discovery-cluster
           spec:
             containers:
-            - image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+            - image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
             supportedModelFormats:
             - name: aim

--- a/test/chainsaw/tests/aim/templates/discovery-results-cluster/cluster-image.yaml
+++ b/test/chainsaw/tests/aim/templates/discovery-results-cluster/cluster-image.yaml
@@ -3,7 +3,7 @@ kind: AIMClusterImage
 metadata:
   name: llama-3-8b-cluster-discovery
 spec:
-  image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+  image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
   defaultServiceTemplate: llama-3-8b-latency-discovery-cluster
   resources:
     limits:

--- a/test/chainsaw/tests/aim/templates/discovery-results-namespace/chainsaw-test.yaml
+++ b/test/chainsaw/tests/aim/templates/discovery-results-namespace/chainsaw-test.yaml
@@ -74,6 +74,6 @@ spec:
             name: llama-3-8b-latency-discovery-namespace
           spec:
             containers:
-            - image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+            - image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
             supportedModelFormats:
             - name: aim

--- a/test/chainsaw/tests/aim/templates/discovery-results-namespace/namespace-image.yaml
+++ b/test/chainsaw/tests/aim/templates/discovery-results-namespace/namespace-image.yaml
@@ -3,7 +3,7 @@ kind: AIMImage
 metadata:
   name: llama-3-8b-namespace-discovery
 spec:
-  image: ghcr.io/silogen/aim:0.4.0-meta-llama-llama-3.1-8b-instruct-v20251006
+  image: ghcr.io/silogen/aim:0.5.0-meta-llama-llama-3.1-8b-instruct-v20251014
   defaultServiceTemplate: llama-3-8b-latency-discovery-namespace
   resources:
     limits:


### PR DESCRIPTION
# Description

* Update test images to latest AIM version
* Disable KServe model downloading to prevent double caching

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [x] Existing workload examples run to completion after my changes (if applicable)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes