### PR TITLE
remove service account from keychain

### DIFF
--- a/internal/controller/aim/shared/image_inspector.go
+++ b/internal/controller/aim/shared/image_inspector.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/google/go-containerregistry/pkg/authn"
 	"github.com/google/go-containerregistry/pkg/authn/k8schain"
+	kauth "github.com/google/go-containerregistry/pkg/authn/kubernetes"
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	corev1 "k8s.io/api/core/v1"
@@ -150,7 +151,7 @@ func InspectImage(
 		kc, err := k8schain.New(ctx, clientset, k8schain.Options{
 			Namespace:          namespace,
 			ImagePullSecrets:   secretNames,
-			ServiceAccountName: "",
+			ServiceAccountName: kauth.NoServiceAccount,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("failed to create k8s keychain: %w", err)


### PR DESCRIPTION
# Description

They Keychain used to connect to the OCI registry for metadata inspection was requesting a service account `""`, which was interpreted as meaning `default`. This caused issues in some clusters. The service account requirement is removed, and the keychain is built just from the image pull secret.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [ ] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [ ] Existing workload examples run to completion after my changes (if applicable)
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes