### PR TITLE
add missing node affinity selectors

### DIFF
--- a/internal/controller/aim/shared/constants.go
+++ b/internal/controller/aim/shared/constants.go
@@ -70,6 +70,9 @@ const (
 	// Cache type label values.
 	LabelValueCacheTypeTemplateCache = "template-cache"
 	LabelValueCacheTypeTempService   = "temporary-service-cache"
+
+	// NodeLabelAMDGPUDeviceID is the primary node label for AMD GPU device IDs (e.g., "74a1" for MI300X)
+	NodeLabelAMDGPUDeviceID = "amd.com/gpu.device-id"
 )
 
 var (

--- a/internal/controller/aim/shared/gpu_resources.go
+++ b/internal/controller/aim/shared/gpu_resources.go
@@ -27,6 +27,7 @@ package shared
 import (
 	"context"
 	"regexp"
+	"sort"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -34,6 +35,47 @@ import (
 
 	aimv1alpha1 "github.com/silogen/kaiwo/apis/aim/v1alpha1"
 )
+
+var KnownAmdGpuDevices = map[string]string{
+	// AMD Instinct
+	"738c": "MI100",
+	"738e": "MI100",
+	"7408": "MI250X",
+	"740c": "MI250X", // MI250/MI250X
+	"740f": "MI210",
+	"7410": "MI210", // MI210 VF
+	"74a0": "MI300A",
+	"74a1": "MI300X",
+	"74a2": "MI308X",
+	"74a5": "MI325X",
+	"74a8": "MI308X", // MI308X HF
+	"74a9": "MI300X", // MI300X HF
+	"74b5": "MI300X", // MI300X VF
+	"74b6": "MI308X",
+	"74b9": "MI325X", // MI325X VF
+	"74bd": "MI300X", // MI300X HF
+	"75a0": "MI350X",
+	"75a3": "MI355X",
+	"75b0": "MI350X", // MI350X VF
+	"75b3": "MI355X", // MI355X VF
+	// AMD Radeon Pro
+	"7460": "V710",
+	"7461": "V710", // Radeon Pro V710 MxGPU
+	"7448": "W7900",
+	"744a": "W7900", // W7900 Dual Slot
+	"7449": "W7800", // W7800 48GB
+	"745e": "W7800",
+	"73a2": "W6900X",
+	"73a3": "W6800",  // W6800 GL-XL
+	"73ab": "W6800X", // W6800X / W6800X Duo
+	"73a1": "V620",
+	"73ae": "V620", // Radeon Pro V620 MxGPU
+	// AMD Radeon
+	"7550": "RX9070", // RX 9070 / 9070 XT
+	"744c": "RX7900", // RX 7900 XT / 7900 XTX / 7900 GRE / 7900M
+	"73af": "RX6900",
+	"73bf": "RX6800", // RX 6800 / 6800 XT / 6900 XT
+}
 
 // GPUResourceInfo contains GPU resource information for a specific GPU model.
 type GPUResourceInfo struct {
@@ -127,48 +169,7 @@ func mapAMDDeviceIDToModel(deviceID string) string {
 	// Remove "0x" prefix if present
 	deviceID = strings.TrimPrefix(strings.ToLower(deviceID), "0x")
 
-	knownDevices := map[string]string{
-		// AMD Instinct
-		"738c": "MI100",
-		"738e": "MI100",
-		"7408": "MI250X",
-		"740c": "MI250X", // MI250/MI250X
-		"740f": "MI210",
-		"7410": "MI210", // MI210 VF
-		"74a0": "MI300A",
-		"74a1": "MI300X",
-		"74a2": "MI308X",
-		"74a5": "MI325X",
-		"74a8": "MI308X", // MI308X HF
-		"74a9": "MI300X", // MI300X HF
-		"74b5": "MI300X", // MI300X VF
-		"74b6": "MI308X",
-		"74b9": "MI325X", // MI325X VF
-		"74bd": "MI300X", // MI300X HF
-		"75a0": "MI350X",
-		"75a3": "MI355X",
-		"75b0": "MI350X", // MI350X VF
-		"75b3": "MI355X", // MI355X VF
-		// AMD Radeon Pro
-		"7460": "V710",
-		"7461": "V710", // Radeon Pro V710 MxGPU
-		"7448": "W7900",
-		"744a": "W7900", // W7900 Dual Slot
-		"7449": "W7800", // W7800 48GB
-		"745e": "W7800",
-		"73a2": "W6900X",
-		"73a3": "W6800",  // W6800 GL-XL
-		"73ab": "W6800X", // W6800X / W6800X Duo
-		"73a1": "V620",
-		"73ae": "V620", // Radeon Pro V620 MxGPU
-		// AMD Radeon
-		"7550": "RX9070", // RX 9070 / 9070 XT
-		"744c": "RX7900", // RX 7900 XT / 7900 XTX / 7900 GRE / 7900M
-		"73af": "RX6900",
-		"73bf": "RX6800", // RX 6800 / 6800 XT / 6900 XT
-	}
-
-	if model, ok := knownDevices[deviceID]; ok {
+	if model, ok := KnownAmdGpuDevices[deviceID]; ok {
 		return model
 	}
 
@@ -331,6 +332,29 @@ func ListAvailableGPUs(ctx context.Context, k8sClient client.Client) ([]string, 
 	}
 
 	return gpuTypes, nil
+}
+
+// GetAMDDeviceIDsForModel returns all AMD device IDs that map to a given GPU model name.
+// This is the inverse of mapAMDDeviceIDToModel, allowing lookup of all device IDs for a model.
+// Example: GetAMDDeviceIDsForModel("MI300X") returns ["74a1", "74a9", "74b5", "74bd"]
+// Returns empty slice if the model is not found or is not an AMD GPU.
+func GetAMDDeviceIDsForModel(modelName string) []string {
+	// Normalize the model name for comparison
+	normalized := normalizeGPUModel(modelName)
+
+	var deviceIDs []string
+	for deviceID, model := range KnownAmdGpuDevices {
+		if model == normalized {
+			deviceIDs = append(deviceIDs, deviceID)
+		}
+	}
+
+	// Sort device IDs to ensure consistent ordering across reconciliations
+	// Map iteration order in Go is randomized, so we must sort to avoid
+	// triggering unnecessary updates when the list is semantically identical
+	sort.Strings(deviceIDs)
+
+	return deviceIDs
 }
 
 // TemplateRequiresGPU returns true if the template spec declares a GPU selector with a model.

--- a/internal/controller/aim/shared/kserve.go
+++ b/internal/controller/aim/shared/kserve.go
@@ -352,6 +352,9 @@ func BuildInferenceService(serviceState aimstate.ServiceState, ownerRef metav1.O
 		inferenceService.Spec.Predictor.MaxReplicas = *serviceState.Replicas
 	}
 
+	// Add GPU node selector based on template GPU model
+	addGPUNodeSelector(inferenceService, serviceState.Template)
+
 	return inferenceService
 }
 
@@ -453,6 +456,65 @@ func quantityGi(value int64) resource.Quantity {
 		return resource.Quantity{}
 	}
 	return resource.MustParse(fmt.Sprintf("%dGi", value))
+}
+
+// addGPUNodeSelector adds node selector based on GPU model from template.
+// Uses AMD GPU device ID labels to ensure the pod lands on compatible nodes.
+// Supports multiple device IDs per GPU model (e.g., MI300X has 74a1, 74a9, 74b5, 74bd).
+// Uses node affinity with RequiredDuringSchedulingIgnoredDuringExecution for strict placement.
+func addGPUNodeSelector(isvc *servingv1beta1.InferenceService, template aimstate.TemplateState) {
+	if template.Status == nil {
+		return
+	}
+
+	gpuModel := template.Status.Profile.Metadata.GPU
+	if gpuModel == "" {
+		return
+	}
+
+	// Get all device IDs that match this GPU model
+	deviceIDs := GetAMDDeviceIDsForModel(gpuModel)
+	if len(deviceIDs) == 0 {
+		// Not an AMD GPU or unknown model - skip node selector
+		return
+	}
+
+	// Always use node affinity (handles both single and multiple device IDs uniformly)
+	addGPUNodeAffinity(isvc, deviceIDs)
+}
+
+// addGPUNodeAffinity adds node affinity rules to match any of the given AMD GPU device IDs.
+// Uses RequiredDuringSchedulingIgnoredDuringExecution for strict placement requirements.
+// Works for both single device IDs (e.g., MI300A) and multiple device IDs (e.g., MI300X).
+func addGPUNodeAffinity(isvc *servingv1beta1.InferenceService, deviceIDs []string) {
+	// Build match expression for device ID label
+	var matchExpressions []corev1.NodeSelectorRequirement
+
+	// Match against primary label (amd.com/gpu.device-id) with In operator
+	// This allows matching any of the provided device IDs
+	matchExpressions = append(matchExpressions, corev1.NodeSelectorRequirement{
+		Key:      NodeLabelAMDGPUDeviceID,
+		Operator: corev1.NodeSelectorOpIn,
+		Values:   deviceIDs,
+	})
+
+	// Initialize affinity if not present
+	if isvc.Spec.Predictor.Affinity == nil {
+		isvc.Spec.Predictor.Affinity = &corev1.Affinity{}
+	}
+	if isvc.Spec.Predictor.Affinity.NodeAffinity == nil {
+		isvc.Spec.Predictor.Affinity.NodeAffinity = &corev1.NodeAffinity{}
+	}
+	if isvc.Spec.Predictor.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution == nil {
+		isvc.Spec.Predictor.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution = &corev1.NodeSelector{}
+	}
+
+	// Set node selector term with match expressions (replace, not append, to avoid growing on each reconcile)
+	isvc.Spec.Predictor.Affinity.NodeAffinity.RequiredDuringSchedulingIgnoredDuringExecution.NodeSelectorTerms = []corev1.NodeSelectorTerm{
+		{
+			MatchExpressions: matchExpressions,
+		},
+	}
 }
 
 // GetClusterServingRuntime fetches a ClusterServingRuntime by name


### PR DESCRIPTION
# Description

So far we have dealt with homogeneous clusters and thus which template has been selected hasn't matter. In order to ensure templates keep working with heterogeneous clusters, adding node affinity selectors to the KServe inference services.
