### PR TITLE
Propagate runtimeConfigName from AIMService to AIMTemplateCache

### DIFF
--- a/internal/controller/aim/aimservice_controller.go
+++ b/internal/controller/aim/aimservice_controller.go
@@ -437,9 +437,10 @@ func (r *AIMServiceReconciler) planTemplateCache(ctx context.Context, logger log
 				},
 			},
 			Spec: aimv1alpha1.AIMTemplateCacheSpec{
-				TemplateRef:      obs.TemplateName,
-				StorageClassName: storageClassName,
-				Env:              service.Spec.Env,
+				TemplateRef:       obs.TemplateName,
+				StorageClassName:  storageClassName,
+				Env:               service.Spec.Env,
+				RuntimeConfigName: service.Spec.RuntimeConfigName,
 			},
 		}
 


### PR DESCRIPTION
When an AIMService creates an AIMTemplateCache, the runtimeConfigName field was not being propagated. This caused the template cache and its model caches to use the default runtime config instead of the service's specified configuration.

This change ensures runtimeConfigName flows from AIMService to AIMTemplateCache, completing the propagation chain to AIMModelCache.
