### PR TITLE
Kind cluster snapshot and restore

### DIFF
--- a/.github/workflows/recreate_kind.yaml
+++ b/.github/workflows/recreate_kind.yaml
@@ -118,6 +118,10 @@ jobs:
           docker system prune -af --volumes || true
           wait
 
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
       - name: Log in to GHCR
         run: |
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
@@ -138,10 +142,6 @@ jobs:
           chmod +x ./test/scripts/*.sh
           echo "Restoring snapshot: $VERSION_TAG with $NUM_WORKERS workers"
           time ./test/scripts/recreate_kind.sh "$VERSION_TAG" "$NUM_WORKERS"
-
-      - uses: actions/setup-go@v5
-        with:
-          go-version-file: go.mod
 
       - name: Download CLI artifact
         uses: actions/download-artifact@v4

--- a/.github/workflows/recreate_kind.yaml
+++ b/.github/workflows/recreate_kind.yaml
@@ -1,6 +1,13 @@
 name: recreate-kind
 
 on:
+  push:
+    branches: [main]
+    paths-ignore:
+      - 'docs/**'
+  pull_request:
+    paths-ignore:
+      - 'docs/**'
   workflow_dispatch:
     inputs:
       version_tag:
@@ -14,6 +21,10 @@ on:
         default: '5'
         type: string
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   packages: read
@@ -21,6 +32,9 @@ permissions:
 env:
   CLUSTER_NAME: kaiwo-test
   REPO_URL: ghcr.io/silogen/kaiwo
+  # Defaults for auto-triggered runs (push/PR)
+  DEFAULT_VERSION_TAG: '0.1'
+  DEFAULT_NUM_WORKERS: '5'
 
 jobs:
   recreate-kind:
@@ -63,10 +77,12 @@ jobs:
 
       - name: Recreate Kind cluster from snapshot
         env:
-          VERSION_TAG: ${{ inputs.version_tag }}
-          NUM_WORKERS: ${{ inputs.num_workers }}
+          # Use inputs if available (manual dispatch), otherwise use defaults
+          VERSION_TAG: ${{ inputs.version_tag || env.DEFAULT_VERSION_TAG }}
+          NUM_WORKERS: ${{ inputs.num_workers || env.DEFAULT_NUM_WORKERS }}
         run: |
           chmod +x ./test/scripts/*.sh
+          echo "Restoring snapshot: $VERSION_TAG with $NUM_WORKERS workers"
           time ./test/scripts/recreate_kind.sh "$VERSION_TAG" "$NUM_WORKERS"
 
       - name: Verify cluster health

--- a/.github/workflows/recreate_kind.yaml
+++ b/.github/workflows/recreate_kind.yaml
@@ -1,0 +1,95 @@
+name: recreate-kind
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_tag:
+        description: 'Snapshot version tag to restore (e.g., v1.0.0)'
+        required: false
+        default: '0.1'
+        type: string
+      num_workers:
+        description: 'Number of worker nodes'
+        required: false
+        default: '5'
+        type: string
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  CLUSTER_NAME: kaiwo-test
+  REPO_URL: ghcr.io/silogen/kaiwo
+
+jobs:
+  recreate-kind:
+    name: Recreate Kind cluster from snapshot
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free disk space
+        shell: bash
+        run: |
+          set -euo pipefail
+          TARGETS=(
+            "/usr/local/lib/android"
+            "/usr/share/dotnet"
+            "/opt/ghc"
+            "/opt/hostedtoolcache"
+            "/usr/local/share/boost"
+            "/usr/local/share/powershell"
+            "/usr/share/swift"
+          )
+          echo "Deleting large preinstalled SDKs/tools..."
+          for d in "${TARGETS[@]}"; do
+            if [[ -e "$d" ]]; then
+              sudo rm -rf "$d" >/dev/null 2>&1 &
+            fi
+          done
+          docker system prune -af --volumes || true
+          wait
+
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Install kind CLI
+        run: |
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.26.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          kind version
+
+      - name: Recreate Kind cluster from snapshot
+        env:
+          VERSION_TAG: ${{ inputs.version_tag }}
+          NUM_WORKERS: ${{ inputs.num_workers }}
+        run: |
+          chmod +x ./test/scripts/*.sh
+          time ./test/scripts/recreate_kind.sh "$VERSION_TAG" "$NUM_WORKERS"
+
+      - name: Verify cluster health
+        run: |
+          export KUBECONFIG="$(pwd)/kaiwo_test_kubeconfig.yaml"
+          echo "=== Node status ==="
+          kubectl get nodes -o wide
+          echo ""
+          echo "=== Pod status (all namespaces) ==="
+          kubectl get pods -A
+          echo ""
+          echo "=== Kueue status ==="
+          kubectl get pods -n kueue-system
+          kubectl get clusterqueue || true
+
+      - name: Debug on failure
+        if: failure()
+        run: |
+          echo "=== Docker containers ==="
+          docker ps -a
+          echo ""
+          echo "=== Kind clusters ==="
+          kind get clusters || true
+          echo ""
+          echo "=== Docker logs (control-plane) ==="
+          docker logs kaiwo-test-control-plane 2>&1 | tail -100 || true

--- a/.github/workflows/recreate_kind.yaml
+++ b/.github/workflows/recreate_kind.yaml
@@ -35,11 +35,64 @@ env:
   # Defaults for auto-triggered runs (push/PR)
   DEFAULT_VERSION_TAG: '0.1'
   DEFAULT_NUM_WORKERS: '5'
+  TTL_TAG: 1h
 
 jobs:
-  recreate-kind:
-    name: Recreate Kind cluster from snapshot
+  build-image:
+    name: Build & push (ttl.sh)
+#    needs: test                   # <-- waits for tests to pass
     runs-on: ubuntu-latest
+    outputs:
+      image: ${{ steps.vars.outputs.full_image }}
+      repo: ${{ steps.vars.outputs.repo }}
+      tag: ${{ steps.vars.outputs.tag }}
+    steps:
+    - uses: actions/checkout@v4
+    - uses: docker/setup-qemu-action@v3
+    - uses: docker/setup-buildx-action@v3
+    - uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Compute ttl.sh image ref
+      id: vars
+      shell: bash
+      run: |
+        ID=$(uuidgen | tr '[:upper:]' '[:lower:]')
+        REPO="ttl.sh/${ID}"
+        TAG="${{ env.TTL_TAG }}"
+        echo "repo=${REPO}"                >> "$GITHUB_OUTPUT"
+        echo "tag=${TAG}"                  >> "$GITHUB_OUTPUT"
+        echo "full_image=${REPO}:${TAG}"   >> "$GITHUB_OUTPUT"
+
+    - name: Build & push to ttl.sh
+      run: |
+        TTL=${{ env.TTL_TAG }} IMAGE_NAME=${{ steps.vars.outputs.full_image }} \
+        bash ./kaiwo.sh --build --push=ttl.sh
+
+    - name: Build CLI binary
+      run: |
+        make build-cli
+        make build-log
+        mkdir -p builds
+        cp bin/kaiwo builds/
+
+    - name: Upload CLI artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: kaiwo-builds
+        path: builds
+        if-no-files-found: error
+        retention-days: 5
+
+  e2e-recreated-kind:
+    name: Recreate Kind cluster from snapshot
+    needs: build-image
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        installer: [kustomization, helm]
     steps:
       - uses: actions/checkout@v4
 
@@ -86,27 +139,85 @@ jobs:
           echo "Restoring snapshot: $VERSION_TAG with $NUM_WORKERS workers"
           time ./test/scripts/recreate_kind.sh "$VERSION_TAG" "$NUM_WORKERS"
 
-      - name: Verify cluster health
-        run: |
-          export KUBECONFIG="$(pwd)/kaiwo_test_kubeconfig.yaml"
-          echo "=== Node status ==="
-          kubectl get nodes -o wide
-          echo ""
-          echo "=== Pod status (all namespaces) ==="
-          kubectl get pods -A
-          echo ""
-          echo "=== Kueue status ==="
-          kubectl get pods -n kueue-system
-          kubectl get clusterqueue || true
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
 
-      - name: Debug on failure
+      - name: Download CLI artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: kaiwo-builds
+          path: builds
+
+      - name: Make CLI executable
+        run: |
+          chmod +x builds/kaiwo
+          chmod +x builds/log
+          ls -l builds
+
+      - name: Install Chainsaw
+        uses: kyverno/action-install-chainsaw@v0.2.12
+        with:
+          release: v0.2.12
+
+      - name: Install Helmfile
+        run: |
+          curl -Lo helmfile.tar.gz https://github.com/helmfile/helmfile/releases/download/v1.1.5/helmfile_1.1.5_linux_amd64.tar.gz
+          tar -xzf helmfile.tar.gz
+          chmod +x ./helmfile
+          sudo mv ./helmfile /usr/local/bin/helmfile
+          rm helmfile.tar.gz
+          helmfile version
+
+      - name: Install CRDs and Deploy (${{ matrix.installer }})
+        env:
+          IMAGE_NAME: ${{ needs.build-image.outputs.image }}
+        run: |
+          bash ./kaiwo.sh --install-crds --deploy-via=${{ matrix.installer }} up
+
+      - name: Wait for rollout
+        run: |
+          kubectl -n kaiwo-system rollout status deployment/kaiwo-controller-manager --timeout=300s
+          kubectl -n kube-system rollout status deployment/kaiwo-scheduler --timeout=300s
+          kubectl -n kaiwo-system get pods -o wide
+
+      - name: Debug rollout failure
         if: failure()
         run: |
-          echo "=== Docker containers ==="
-          docker ps -a
-          echo ""
-          echo "=== Kind clusters ==="
-          kind get clusters || true
-          echo ""
-          echo "=== Docker logs (control-plane) ==="
-          docker logs kaiwo-test-control-plane 2>&1 | tail -100 || true
+          echo "=== Deployment status ==="
+          kubectl -n kaiwo-system get deployments -o wide
+          kubectl -n kube-system get deployments -o wide
+
+          echo "=== Pod status ==="
+          kubectl -n kaiwo-system get pods -o wide
+          kubectl -n kube-system get pods -o wide
+
+          echo "=== Controller manager pod details ==="
+          kubectl -n kaiwo-system describe deployment kaiwo-controller-manager
+          kubectl -n kaiwo-system describe pods -l control-plane=controller-manager
+
+          echo "=== Scheduler pod details ==="
+          kubectl -n kube-system describe deployment kaiwo-scheduler
+          kubectl -n kube-system describe pods -l component=kaiwo-scheduler
+
+          echo "=== Controller manager logs ==="
+          kubectl -n kaiwo-system logs -l control-plane=controller-manager --tail=100 --all-containers=true || true
+
+          echo "=== Scheduler logs ==="
+          kubectl -n kube-system logs -l component=kaiwo-scheduler --tail=100 --all-containers=true || true
+
+          echo "=== Events ==="
+          kubectl -n kaiwo-system get events --sort-by='.lastTimestamp'
+          kubectl -n kube-system get events --sort-by='.lastTimestamp'
+
+      - name: Run E2E tests
+        run: |
+          cd test
+          make test-kind
+
+      - name: Disk usage report (post-mortem)
+        if: always()
+        run: |-
+          df -h
+          sudo du -xh /var/lib/docker | sort -rh | head -n 20
+          sudo du -xh /home/runner/work | sort -rh | head -n 20

--- a/.github/workflows/recreate_kind.yaml
+++ b/.github/workflows/recreate_kind.yaml
@@ -66,7 +66,8 @@ jobs:
           wait
 
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+        run: |
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
       - name: Install kind CLI
         run: |

--- a/test/scripts/pull_kind_snapshot.sh
+++ b/test/scripts/pull_kind_snapshot.sh
@@ -23,7 +23,7 @@ TMPDIR=$(mktemp -d)
 trap "rm -rf $TMPDIR" EXIT
 
 # Pull all images in parallel
-echo "Pulling ${#ALL_NODES[@]} snapshot images in parallel..."
+echo "Pulling ${#ALL_NODES[@]} snapshot images..."
 for NODE in "${ALL_NODES[@]}"; do
   IMAGE="${REPO_URL}/kind-snapshot-${NODE}:${VERSION_TAG}"
   (

--- a/test/scripts/pull_kind_snapshot.sh
+++ b/test/scripts/pull_kind_snapshot.sh
@@ -6,6 +6,7 @@ CLUSTER_NAME=${CLUSTER_NAME:-"kaiwo-test"}
 VERSION_TAG=${1:?Usage: $0 <version_tag> [num_workers]}
 NUM_WORKERS=${2:-5}
 
+
 echo "Pulling Kind cluster snapshots for '$CLUSTER_NAME' with tag '$VERSION_TAG' from '$REPO_URL'..."
 
 # Build list of expected container names
@@ -18,8 +19,8 @@ done
 ALL_NODES=("$CONTROL_PLANE" "${WORKERS[@]}")
 
 # Create temp directory for tracking results
-RESULTS_DIR=$(mktemp -d)
-trap "rm -rf $RESULTS_DIR" EXIT
+TMPDIR=$(mktemp -d)
+trap "rm -rf $TMPDIR" EXIT
 
 # Pull all images in parallel
 echo "Pulling ${#ALL_NODES[@]} snapshot images in parallel..."

--- a/test/scripts/pull_kind_snapshot.sh
+++ b/test/scripts/pull_kind_snapshot.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+set -euo pipefail
+
+REPO_URL=${REPO_URL:-"ghcr.io/silogen/kaiwo"}
+CLUSTER_NAME=${CLUSTER_NAME:-"kaiwo-test"}
+VERSION_TAG=${1:?Usage: $0 <version_tag> [num_workers]}
+NUM_WORKERS=${2:-5}
+
+echo "Pulling Kind cluster snapshots for '$CLUSTER_NAME' with tag '$VERSION_TAG' from '$REPO_URL'..."
+
+# Build list of expected container names
+CONTROL_PLANE="${CLUSTER_NAME}-control-plane"
+WORKERS=()
+for i in $(seq 1 $NUM_WORKERS); do
+  [[ $i -eq 1 ]] && WORKERS+=("${CLUSTER_NAME}-worker") || WORKERS+=("${CLUSTER_NAME}-worker${i}")
+done
+
+ALL_NODES=("$CONTROL_PLANE" "${WORKERS[@]}")
+
+# Create temp directory for tracking results
+RESULTS_DIR=$(mktemp -d)
+trap "rm -rf $RESULTS_DIR" EXIT
+
+# Pull all images in parallel
+echo "Pulling ${#ALL_NODES[@]} snapshot images in parallel..."
+for NODE in "${ALL_NODES[@]}"; do
+  IMAGE="${REPO_URL}/kind-snapshot-${NODE}:${VERSION_TAG}"
+  (
+    if docker pull "$IMAGE" > "$TMPDIR/${NODE}.log" 2>&1; then
+      echo "  ✓ $IMAGE"
+      touch "$TMPDIR/${NODE}.success"
+    else
+      echo "  ✗ $IMAGE"
+      touch "$TMPDIR/${NODE}.failed"
+    fi
+  ) &
+done
+
+# Wait for all pulls to complete
+wait
+
+# Check for failures
+FAILED=()
+for NODE in "${ALL_NODES[@]}"; do
+  if [[ -f "$TMPDIR/${NODE}.failed" ]]; then
+    FAILED+=("${REPO_URL}/kind-snapshot-${NODE}:${VERSION_TAG}")
+  fi
+done
+
+if [[ ${#FAILED[@]} -gt 0 ]]; then
+  echo ""
+  echo "ERROR: Failed to pull the following images:"
+  for IMG in "${FAILED[@]}"; do
+    echo "  - $IMG"
+  done
+  exit 1
+fi
+
+echo ""
+echo "Successfully pulled all snapshot images:"
+for NODE in "${ALL_NODES[@]}"; do
+  IMAGE="${REPO_URL}/kind-snapshot-${NODE}:${VERSION_TAG}"
+  echo "  $IMAGE"
+done

--- a/test/scripts/recreate_kind.sh
+++ b/test/scripts/recreate_kind.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_URL=${REPO_URL:-"ghcr.io/silogen/kaiwo"}
+CLUSTER_NAME=${CLUSTER_NAME:-"kaiwo-test"}
+VERSION_TAG=${1:?Usage: $0 <version_tag> [num_workers]}
+NUM_WORKERS=${2:-5}
+KIND_CONFIG="${SCRIPT_DIR}/../kind/kind-test-cluster.yaml"
+
+echo "=============================================="
+echo "Recreating Kind cluster '$CLUSTER_NAME' from snapshot '$VERSION_TAG'"
+echo "=============================================="
+
+# Step 1: Pull snapshot images
+echo ""
+echo "Step 1: Pulling snapshot images..."
+echo "----------------------------------------------"
+REPO_URL="$REPO_URL" CLUSTER_NAME="$CLUSTER_NAME" "$SCRIPT_DIR/pull_kind_snapshot.sh" "$VERSION_TAG" "$NUM_WORKERS"
+
+# Step 2: Delete existing cluster if present
+echo ""
+echo "Step 2: Deleting existing cluster (if any)..."
+echo "----------------------------------------------"
+if kind get clusters 2>/dev/null | grep -q "^${CLUSTER_NAME}$"; then
+  echo "Deleting existing cluster '$CLUSTER_NAME'..."
+  kind delete cluster --name "$CLUSTER_NAME"
+else
+  echo "No existing cluster '$CLUSTER_NAME' found."
+fi
+
+# Step 3: Create fresh Kind cluster
+echo ""
+echo "Step 3: Creating fresh Kind cluster..."
+echo "----------------------------------------------"
+if [[ ! -f "$KIND_CONFIG" ]]; then
+  echo "ERROR: Kind config not found at: $KIND_CONFIG"
+  exit 1
+fi
+kind create cluster --name "$CLUSTER_NAME" --config "$KIND_CONFIG"
+
+# Step 4: Restore from snapshot
+echo ""
+echo "Step 4: Restoring cluster state from snapshot..."
+echo "----------------------------------------------"
+REPO_URL="$REPO_URL" CLUSTER_NAME="$CLUSTER_NAME" "$SCRIPT_DIR/restore_kind.sh" "$VERSION_TAG" "$NUM_WORKERS"
+
+echo ""
+echo "=============================================="
+echo "Kind cluster '$CLUSTER_NAME' recreated successfully!"
+echo "=============================================="
+
+

--- a/test/scripts/restore_kind.sh
+++ b/test/scripts/restore_kind.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+set -euo pipefail
+
+CLUSTER_NAME=${CLUSTER_NAME:-"kaiwo-test"}
+VERSION_TAG=${1:?Usage: $0 <version_tag> [num_workers]}
+NUM_WORKERS=${2:-5}
+
+echo "Restoring Kind cluster '$CLUSTER_NAME' from tag '$VERSION_TAG'..."
+
+# Expected container names
+CONTROL_PLANE="${CLUSTER_NAME}-control-plane"
+WORKERS=()
+for i in $(seq 1 $NUM_WORKERS); do
+  [[ $i -eq 1 ]] && WORKERS+=("${CLUSTER_NAME}-worker") || WORKERS+=("${CLUSTER_NAME}-worker${i}")
+done
+
+ALL_NODES=("$CONTROL_PLANE" "${WORKERS[@]}")
+
+# Verify all snapshot images exist
+echo "Verifying snapshot images..."
+for NODE in "${ALL_NODES[@]}"; do
+  IMAGE="kind-snapshot-${NODE}:${VERSION_TAG}"
+  if ! docker image inspect "$IMAGE" &>/dev/null; then
+    echo "ERROR: Missing snapshot image: $IMAGE"
+    exit 1
+  fi
+done
+
+echo "Stopping containers..."
+docker stop "${ALL_NODES[@]}" 2>/dev/null || true
+
+echo "Restoring from snapshots..."
+for NODE in "${ALL_NODES[@]}"; do
+  IMAGE="kind-snapshot-${NODE}:${VERSION_TAG}"
+  
+  # Get the current container's config for recreation
+  if docker inspect "$NODE" &>/dev/null; then
+    # Extract key settings
+    NETWORK=$(docker inspect "$NODE" --format '{{range $k, $v := .NetworkSettings.Networks}}{{$k}}{{end}}')
+    PRIVILEGED=$(docker inspect "$NODE" --format '{{.HostConfig.Privileged}}')
+    
+    # Extract port mappings (critical for control-plane!)
+    PORT_ARGS=""
+    if [[ "$NODE" == *"control-plane"* ]]; then
+      HOST_PORT=$(docker inspect "$NODE" --format '{{(index (index .HostConfig.PortBindings "6443/tcp") 0).HostPort}}' 2>/dev/null || true)
+      if [[ -n "$HOST_PORT" ]]; then
+        PORT_ARGS="-p 127.0.0.1:${HOST_PORT}:6443"
+        echo "  Preserving API server port mapping: ${HOST_PORT}:6443"
+      else
+        echo "  WARNING: Could not detect original API server port!"
+      fi
+    fi
+    
+    docker rm "$NODE"
+
+    # Create new container from snapshot, copying critical settings
+    
+    docker create \
+      --name "$NODE" \
+      --hostname "$NODE" \
+      --privileged="$PRIVILEGED" \
+      --network "$NETWORK" \
+      $PORT_ARGS \
+      --label "io.x-k8s.kind.cluster=$CLUSTER_NAME" \
+      --label "io.x-k8s.kind.role=$(echo $NODE | grep -q control-plane && echo control-plane || echo worker)" \
+      --tmpfs /tmp --tmpfs /run \
+      --volume /var --volume /lib/modules:/lib/modules:ro \
+      "$IMAGE"
+    
+    echo "  Restored: $NODE"
+  fi
+done
+
+echo "Starting containers..."
+docker start "${ALL_NODES[@]}"
+
+echo "Waiting for containerd to start..."
+sleep 10
+
+# Restore the /var directory of each container
+for NODE in "${ALL_NODES[@]}"; do
+    docker exec "$NODE" bash -c '
+        echo "Restoring /var from snapshot... on '"$NODE"'"
+        systemctl stop containerd kubelet
+        # Extract, ignoring device node creation failures
+        tar -C /var -xzf /var_snapshot.tar.gz 2>&1 | grep -v "Cannot mknod" || true
+        echo "    Restored /var (some device nodes skipped)"
+        systemctl start containerd kubelet
+    ' &
+done
+wait
+
+# Fix node IPs (after /var restore overwrote kubelet config with old IPs)
+echo "Fixing node IPs..."
+for NODE in "${ALL_NODES[@]}"; do
+  NEW_IP=$(docker inspect "$NODE" --format '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}')
+  echo "  $NODE -> $NEW_IP"
+  
+  docker exec "$NODE" sed -i "s/--node-ip=[^ \"]*/--node-ip=$NEW_IP/" /var/lib/kubelet/kubeadm-flags.env 2>/dev/null || true
+  
+  if [[ "$NODE" == *"control-plane"* ]]; then
+    docker exec "$NODE" sed -i "s/--advertise-address=[0-9.]*/--advertise-address=$NEW_IP/" /etc/kubernetes/manifests/kube-apiserver.yaml 2>/dev/null || true
+  fi
+done
+
+
+# Restart kubelet to let it pick up the new IP addresses and var directory
+echo "Restarting kubelet..."
+for NODE in "${ALL_NODES[@]}"; do
+  docker exec "$NODE" systemctl restart kubelet &
+done
+wait
+
+# Extract kubeconfig from the control plane node
+echo "Extracting kubeconfig..."
+KUBECONFIG_FILE="$(pwd)/kaiwo_test_kubeconfig.yaml"
+
+if kind get kubeconfig --name "$CLUSTER_NAME" > "$KUBECONFIG_FILE" 2>/dev/null; then
+  echo "Kubeconfig extracted via kind"
+else
+  echo "Falling back to direct extraction from container..."
+  docker cp "${CONTROL_PLANE}:/etc/kubernetes/admin.conf" "$KUBECONFIG_FILE"
+  
+  API_PORT=$(docker inspect "${CONTROL_PLANE}" --format '{{range $p, $conf := .NetworkSettings.Ports}}{{if eq $p "6443/tcp"}}{{(index $conf 0).HostPort}}{{end}}{{end}}')
+  [[ -n "$API_PORT" ]] && sed -i "s|server: https://.*:6443|server: https://127.0.0.1:${API_PORT}|g" "$KUBECONFIG_FILE"
+fi
+
+echo "Kubeconfig saved to: $KUBECONFIG_FILE"
+
+kubectl --kubeconfig=$KUBECONFIG_FILE get nodes || true
+
+echo "Restore complete!"

--- a/test/scripts/snapshot_kind.sh
+++ b/test/scripts/snapshot_kind.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+set -euo pipefail
+
+CLUSTER_NAME=${CLUSTER_NAME:-"kaiwo-test"}
+VERSION_TAG=${1:?Usage: $0 <version_tag>}
+
+echo "Snapshotting Kind cluster '$CLUSTER_NAME' with tag '$VERSION_TAG'..."
+
+CONTAINERS=$(docker ps -a --filter "label=io.x-k8s.kind.cluster=$CLUSTER_NAME" --format '{{.Names}}')
+
+if [[ -z "$CONTAINERS" ]]; then
+  echo "No containers found for cluster '$CLUSTER_NAME'"
+  exit 1
+fi
+
+# Stop all services and archive /var
+for CONTAINER in $CONTAINERS; do
+  echo "  $CONTAINER: stopping containers and services..."
+  docker exec "$CONTAINER" bash -c '
+    # Stop all containers gracefully via crictl
+    CONTAINER_IDS=$(crictl ps -q 2>/dev/null || true)
+    if [[ -n "$CONTAINER_IDS" ]]; then
+      echo "Stopping containers: $CONTAINER_IDS"
+      echo "$CONTAINER_IDS" | xargs -r -P 10 crictl stop -t 3 2>/dev/null || true
+    fi
+    
+    # Stop containerd and kubelet
+    systemctl stop kubelet containerd 2>/dev/null || true
+    
+    # Wait for everything to settle
+    sleep 3
+  '
+  
+  echo "  $CONTAINER: archiving /var..."
+  docker exec "$CONTAINER" tar -C /var -czf /var_snapshot.tar.gz . &
+done
+wait
+
+echo "Stopping containers..."
+docker stop $CONTAINERS
+
+echo "Committing snapshots..."
+for CONTAINER in $CONTAINERS; do
+  IMAGE_NAME="kind-snapshot-${CONTAINER}:${VERSION_TAG}"
+  echo "  $CONTAINER -> $IMAGE_NAME"
+  docker commit "$CONTAINER" "$IMAGE_NAME"
+done
+
+echo "Restarting containers..."
+docker start $CONTAINERS
+
+echo "Snapshot complete! Images created:"
+docker images --filter "reference=kind-snapshot-*:${VERSION_TAG}" --format "  {{.Repository}}:{{.Tag}}"

--- a/test/scripts/snapshot_kind.sh
+++ b/test/scripts/snapshot_kind.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
+REPO_URL=${REPO_URL:-"ghcr.io/silogen/kaiwo"}
 CLUSTER_NAME=${CLUSTER_NAME:-"kaiwo-test"}
 VERSION_TAG=${1:?Usage: $0 <version_tag>}
 
@@ -41,7 +42,7 @@ docker stop $CONTAINERS
 
 echo "Committing snapshots..."
 for CONTAINER in $CONTAINERS; do
-  IMAGE_NAME="kind-snapshot-${CONTAINER}:${VERSION_TAG}"
+  IMAGE_NAME="${REPO_URL}/kind-snapshot-${CONTAINER}:${VERSION_TAG}"
   echo "  $CONTAINER -> $IMAGE_NAME"
   docker commit "$CONTAINER" "$IMAGE_NAME"
 done
@@ -50,4 +51,4 @@ echo "Restarting containers..."
 docker start $CONTAINERS
 
 echo "Snapshot complete! Images created:"
-docker images --filter "reference=kind-snapshot-*:${VERSION_TAG}" --format "  {{.Repository}}:{{.Tag}}"
+docker images --filter "reference=${REPO_URL}/kind-snapshot-*:${VERSION_TAG}" --format "  {{.Repository}}:{{.Tag}}"


### PR DESCRIPTION
# Description

This snapshots a kind cluster by compressing everything from the /var directory into /var_snapshot.tar.gz and saving the container as a new image. Restore works in reverse, that it remaps a snapshotted container to the kind cluster, extracts /var_snapshot.tar.gz into /var and restarts the cluster.

```
time bash ./test/scripts/setup_kind.sh --skip-static 
...
Cluster is ready!
bash ./test/scripts/setup_kind.sh --skip-static  65.64s user 40.88s system 22% cpu 7:48.99 total
```

```
time sh -c "kind create cluster --name kaiwo-test --config ../kind/kind-test-cluster.yaml && ./restore_kind.sh 0.1"
...
Restore complete!
sh -c   2.89s user 6.39s system 8% cpu 1:53.02 total
```
(note that the restore doesn't do any network traffic in this example, it will take longer when images need to be downloaded)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [x] Existing workload examples run to completion after my changes (if applicable)
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes