### PR TITLE
Fix Helm chart resource files being deleted during CI packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,6 @@ helm-package: build-installer ## Package the Helm chart
 	@sed -i.bak 's/^appVersion:.*/appVersion: "$(APP_VERSION)"/' $(CHART_DIR)/Chart.yaml
 	helm package $(CHART_DIR) --version=$(CHART_VERSION) --app-version=$(APP_VERSION) --destination=dist/
 	@rm -f $(CHART_DIR)/Chart.yaml.bak
-	$(call clean-helm-resources)
 
 .PHONY: helm-install
 helm-install: helm-package ## Install the Helm chart locally
@@ -188,7 +187,6 @@ helm-template: build-installer ## Generate Helm templates for inspection
 	@sed -i.bak 's/^appVersion:.*/appVersion: "$(APP_VERSION)"/' $(CHART_DIR)/Chart.yaml
 	helm template kaiwo $(CHART_DIR) --namespace kaiwo-system --output-dir dist/helm-output/
 	@rm -f $(CHART_DIR)/Chart.yaml.bak
-	$(call clean-helm-resources)
 
 .PHONY: helm-push-oci
 helm-push-oci: helm-package ## Push Helm chart to OCI registry

--- a/chart/rbac-resources.yaml
+++ b/chart/rbac-resources.yaml
@@ -34,6 +34,14 @@ rules:
   - update
   - watch
 - apiGroups:
+  - aim.eai.amd.com
+  resources:
+  - aimservices
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
   - aim.silogen.ai
   resources:
   - aimclustermodels

--- a/docs/docs/reference/crds/config.kaiwo.silogen.ai.md
+++ b/docs/docs/reference/crds/config.kaiwo.silogen.ai.md
@@ -70,10 +70,33 @@ _Appears in:_
 | `nodes` _[KaiwoNodeConfig](#kaiwonodeconfig)_ | Nodes defines the node configuration settings | \{  \} |  |
 | `scheduling` _[KaiwoSchedulingConfig](#kaiwoschedulingconfig)_ | Scheduling contains the configuration Kaiwo uses for workload scheduling | \{  \} |  |
 | `resourceMonitoring` _[KaiwoResourceMonitoringConfig](#kaiworesourcemonitoringconfig)_ | ResourceMonitoring defines the resource-monitoring specific settings | \{  \} |  |
+| `gpuPreemption` _[KaiwoGpuPreemptionConfig](#kaiwogpupreemptionconfig)_ | GpuPreemption configures cluster-wide defaults for the GPU preemption feature.<br />These values sit between per-workload annotations and operator env vars in<br />the resolution chain: annotation > KaiwoConfig > env var > hardcoded fallback.<br />Note: metricsEndpoint and pollingInterval remain env-var-only because<br />changing them requires restarting the metrics scraper. | \{  \} |  |
 | `defaultClusterQueueName` _string_ | DefaultClusterQueueName is the name of the default cluster queue that is used for workloads that don't explicitly specify a cluster queue. | kaiwo |  |
 | `defaultClusterQueueCohortName` _string_ | DefaultClusterQueueCohortName is the name of the default cohort that is used for the default cluster queue.<br />ClusterQueues in the same cohort can share resources. | kaiwo |  |
 | `dynamicallyUpdateDefaultClusterQueue` _boolean_ | DynamicallyUpdateDefaultClusterQueue defines whether the Kaiwo operator should dynamically update default "kaiwo" clusterqueue.<br />If set to true, the operator will make sure that the default clusterqueue is always up to date and reflects total resources available.<br />If nodes are added or removed, the operator will update the default clusterqueue to reflect the current state of the cluster. | false |  |
 | `defaultTopologyName` _string_ | DefaultTopologyName is the name of the default Kueue Topology used for Topology Aware Scheduling.<br />Auto-generated ResourceFlavors reference this topology when DynamicallyUpdateDefaultClusterQueue is enabled. | default-topology |  |
+
+
+#### KaiwoGpuPreemptionConfig
+
+
+
+KaiwoGpuPreemptionConfig configures cluster-wide defaults for the GPU
+preemption feature. All fields are optional; when unset the corresponding
+operator env var (or hardcoded fallback) is used instead.
+
+
+
+_Appears in:_
+- [KaiwoConfigSpec](#kaiwoconfigspec)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `defaultThreshold` _float_ | DefaultThreshold is the utilization percentage below which a workload is<br />considered idle. Overridden by the per-workload annotation. |  | Maximum: 100 <br />Minimum: 0 <br />Optional: \{\} <br /> |
+| `defaultGracePeriod` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#duration-v1-meta)_ | DefaultGracePeriod is the duration a workload must be continuously idle<br />before it becomes eligible for preemption (e.g. "10m", "1h"). |  | Optional: \{\} <br /> |
+| `defaultPolicy` _string_ | DefaultPolicy is the preemption policy: "OnPressure" or "Always". |  | Enum: [OnPressure Always] <br />Optional: \{\} <br /> |
+| `defaultAggregation` _string_ | DefaultAggregation determines how utilization is aggregated across<br />multiple pods: "Min", "Max", or "Avg". |  | Enum: [Min Max Avg] <br />Optional: \{\} <br /> |
+| `defaultTTL` _[Duration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#duration-v1-meta)_ | DefaultTTL controls how long terminal GpuWorkload CRs (Preempted or<br />Deleted) are retained before automatic cleanup (e.g. "24h", "0" for forever). |  | Optional: \{\} <br /> |
 
 
 #### KaiwoNodeConfig

--- a/docs/docs/reference/crds/kaiwo.silogen.ai.md
+++ b/docs/docs/reference/crds/kaiwo.silogen.ai.md
@@ -243,6 +243,24 @@ _Appears in:_
 | `targetPath` _string_ | TargetPath specifies the destination path relative to the data volume's mount point (`DataStorageSpec.MountPath`) where the repository or `path` content should be copied. |  |  |
 
 
+#### GpuMetric
+
+
+
+GpuMetric holds a utilization sample for a single GPU.
+
+
+
+_Appears in:_
+- [TrackedPod](#trackedpod)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `gpuId` _string_ |  |  |  |
+| `utilization` _float_ |  |  | Maximum: 100 <br />Minimum: 0 <br /> |
+| `lastUpdate` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ |  |  |  |
+
+
 #### GpuWorkload
 
 
@@ -289,15 +307,16 @@ _Underlying type:_ _string_
 
 GpuWorkloadPhase represents the lifecycle phase of a tracked GPU workload.
 
-
+_Validation:_
+- Enum: [PendingGpu PendingOther Active Idle Preempting Preempted Deleted ]
 
 _Appears in:_
 - [GpuWorkloadStatus](#gpuworkloadstatus)
 
 | Field | Description |
 | --- | --- |
-| `PendingGpu` | GpuWorkloadPhasePendingGpu indicates pods are unschedulable specifically due to<br />insufficient GPU resources (validated via the scheduler condition message).<br />Acts as the demand signal for OnPressure preemption.<br /> |
-| `PendingOther` | GpuWorkloadPhasePendingOther indicates pods exist but are not yet Running<br />for non-GPU reasons: image pulls, init containers, PVC binding, node affinity,<br />taints, etc. No idle time is counted and the phase does not trigger preemption evaluation.<br /> |
+| `PendingGpu` | GpuWorkloadPhasePendingGpu indicates pods are unschedulable specifically<br />due to insufficient GPU resources (validated via the scheduler condition<br />message). Acts as the demand signal for OnPressure preemption.<br /> |
+| `PendingOther` | GpuWorkloadPhasePendingOther indicates pods exist but are not yet<br />Running for non-GPU reasons: image pulls, init containers, PVC<br />binding, node affinity, taints, etc. No idle time is counted and<br />the phase does not trigger preemption evaluation.<br /> |
 | `Active` | GpuWorkloadPhaseActive indicates pods are running and aggregated GPU<br />utilization is at or above the configured threshold.<br /> |
 | `Idle` | GpuWorkloadPhaseIdle indicates pods are running but aggregated GPU<br />utilization is below the configured threshold.<br /> |
 | `Preempting` | GpuWorkloadPhasePreempting indicates the workload has been claimed for<br />preemption by the evaluator; deletion is in progress.<br /> |
@@ -340,7 +359,7 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `phase` _[GpuWorkloadPhase](#gpuworkloadphase)_ | Phase is the current lifecycle phase of the tracked workload. |  |  |
+| `phase` _[GpuWorkloadPhase](#gpuworkloadphase)_ | Phase is the current lifecycle phase of the tracked workload. |  | Enum: [PendingGpu PendingOther Active Idle Preempting Preempted Deleted ] <br /> |
 | `trackedPods` _[TrackedPod](#trackedpod) array_ | TrackedPods lists pods currently owned by this workload together with<br />per-GPU utilization metrics. Pod entries are maintained by the reconciler;<br />metrics within each pod are updated by the scraper. |  |  |
 | `aggregatedUtilization` _float_ | AggregatedUtilization is computed by the reconciler from TrackedPods<br />using the configured AggregationPolicy. |  |  |
 | `lastMetricsUpdate` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ | LastMetricsUpdate records the last time the scraper wrote utilization data. |  |  |
@@ -680,43 +699,6 @@ _Appears in:_
 | `git` _[GitDownloadItem](#gitdownloaditem) array_ | Git lists any Git downloads |  |  |
 
 
-#### GpuMetric
-
-
-
-GpuMetric holds a utilization sample for a single GPU.
-
-
-
-_Appears in:_
-- [TrackedPod](#trackedpod)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `gpuId` _string_ |  |  |  |
-| `utilization` _float_ |  |  |  |
-| `lastUpdate` _[Time](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#time-v1-meta)_ |  |  |  |
-
-
-#### TrackedPod
-
-
-
-TrackedPod represents a pod owned by this workload together with its
-per-GPU utilization metrics. Pod entries are maintained by the reconciler;
-metrics within each pod are updated by the scraper.
-
-
-
-_Appears in:_
-- [GpuWorkloadStatus](#gpuworkloadstatus)
-
-| Field | Description | Default | Validation |
-| --- | --- | --- | --- |
-| `podName` _string_ |  |  |  |
-| `gpuMetrics` _[GpuMetric](#gpumetric) array_ |  |  |  |
-
-
 #### PreemptionPolicy
 
 _Underlying type:_ _string_
@@ -869,6 +851,25 @@ _Appears in:_
 | `levels` _TopologyLevel array_ | levels define the levels of topology. |  | MaxItems: 8 <br />MinItems: 1 <br />Required: \{\} <br /> |
 
 
+#### TrackedPod
+
+
+
+TrackedPod represents a pod owned by this workload together with its
+per-GPU utilization metrics.  Pod entries are maintained by the reconciler;
+metrics within each pod are updated by the scraper.
+
+
+
+_Appears in:_
+- [GpuWorkloadStatus](#gpuworkloadstatus)
+
+| Field | Description | Default | Validation |
+| --- | --- | --- | --- |
+| `podName` _string_ |  |  |  |
+| `gpuMetrics` _[GpuMetric](#gpumetric) array_ |  |  |  |
+
+
 #### ValueReference
 
 
@@ -903,9 +904,9 @@ _Appears in:_
 
 | Field | Description | Default | Validation |
 | --- | --- | --- | --- |
-| `apiVersion` _string_ |  |  |  |
-| `kind` _string_ |  |  |  |
-| `name` _string_ |  |  |  |
+| `apiVersion` _string_ |  |  | MinLength: 1 <br /> |
+| `kind` _string_ |  |  | MinLength: 1 <br /> |
+| `name` _string_ |  |  | MinLength: 1 <br /> |
 | `uid` _[UID](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#uid-types-pkg)_ |  |  |  |
 
 


### PR DESCRIPTION
- Remove clean-helm-resources calls from helm-package and helm-template Makefile targets to stop deleting rbac-resources.yaml and scheduler-resources.yaml from the chart directory after packaging
- These files are committed to the repo and needed at install time by the Helm templates (.Files.Get), but were being removed after helm package ran, causing the publish-main workflow's git add -A to commit their deletion to the publish-main branch
