### PR TITLE
Fix/kaiwoqueueconfig failed on missing clusterqueue

### DIFF
--- a/internal/controller/kaiwoqueueconfig_controller.go
+++ b/internal/controller/kaiwoqueueconfig_controller.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -160,6 +161,10 @@ func (r *KaiwoQueueConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			"name", latest.Name,
 			"WorkloadStatus", latest.Status.Status,
 		)
+	}
+
+	if queueConfig.Status.Status == kaiwo.QueueConfigStatusFailed {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 	}
 
 	return ctrl.Result{}, nil
@@ -667,7 +672,12 @@ func (r *KaiwoQueueConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return err
 	}
 
-	// Create a predicate to filter when to run the reconciliation on node changes
+	enqueueKaiwoQueueConfig := handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
+		return []reconcile.Request{
+			{NamespacedName: types.NamespacedName{Name: common.KaiwoQueueConfigName}},
+		}
+	})
+
 	nodePred := predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
 			return true
@@ -685,18 +695,18 @@ func (r *KaiwoQueueConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
+	nsPred := predicate.Funcs{
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
+		UpdateFunc:  func(e event.UpdateEvent) bool { return false },
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+	}
+
 	return builder.ControllerManagedBy(mgr).
 		For(&kaiwo.KaiwoQueueConfig{}).
 		Owns(&kueuev1beta1.ClusterQueue{}).
-		Watches(
-			&corev1.Node{},
-			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {
-				return []reconcile.Request{
-					{NamespacedName: types.NamespacedName{Name: common.KaiwoQueueConfigName}},
-				}
-			}),
-			builder.WithPredicates(nodePred),
-		).
+		Watches(&corev1.Node{}, enqueueKaiwoQueueConfig, builder.WithPredicates(nodePred)).
+		Watches(&corev1.Namespace{}, enqueueKaiwoQueueConfig, builder.WithPredicates(nsPred)).
 		Named("kaiwoqueueconfig").
 		Complete(r)
 }

--- a/internal/controller/kaiwoqueueconfig_controller.go
+++ b/internal/controller/kaiwoqueueconfig_controller.go
@@ -28,6 +28,7 @@ import (
 	"context"
 	"fmt"
 	"reflect"
+	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -148,6 +149,9 @@ func (r *KaiwoQueueConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		)
 	}
 
+	if queueConfig.Status.Status == kaiwo.QueueConfigStatusFailed {
+		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
+	}
 	return ctrl.Result{}, nil
 }
 
@@ -264,7 +268,7 @@ func (r *KaiwoQueueConfigReconciler) syncResourceFlavors(ctx context.Context, qu
 		if _, exists := existingFlavorMap[existingFlavor.Name]; !exists {
 			logger.Info("Deleting ResourceFlavor", "name", existingFlavor.Name)
 			err := r.Delete(ctx, &existingFlavor)
-			if err != nil {
+			if err != nil && !errors.IsNotFound(err) {
 				logger.Error(err, "Failed to delete ResourceFlavor", "name", existingFlavor.Name)
 				success = false
 			}
@@ -287,6 +291,13 @@ func (r *KaiwoQueueConfigReconciler) syncTopologies(
 	existingTopologyMap := make(map[string]kueuev1alpha1.Topology)
 
 	for _, kueueTopology := range expectedTopologies {
+		if kueueTopology.Name == "" {
+			// A topology entry with no name in the spec cannot be created — skip it
+			// rather than letting the API-server rejection fail the whole sync.
+			// Root cause: DefaultTopologyName is unset in KaiwoConfig (see fix #2).
+			logger.Info("Skipping Topology with empty name in spec; set defaultTopologyName in KaiwoConfig to resolve")
+			continue
+		}
 		existingTopology, found := controllerutils.FindTopology(existingTopologies.Items, kueueTopology.Name)
 		if !found {
 			logger.Info("Creating Topology", "name", kueueTopology.Name)
@@ -321,7 +332,7 @@ func (r *KaiwoQueueConfigReconciler) syncTopologies(
 		if _, exists := existingTopologyMap[existingTopology.Name]; !exists {
 			logger.Info("Deleting Topology", "name", existingTopology.Name)
 			err := r.Delete(ctx, &existingTopology)
-			if err != nil {
+			if err != nil && !errors.IsNotFound(err) {
 				logger.Error(err, "Failed to delete Topology", "name", existingTopology.Name)
 				success = false
 			}
@@ -403,7 +414,7 @@ func (r *KaiwoQueueConfigReconciler) syncClusterQueues(ctx context.Context, queu
 		if _, exists := expectedQueues[existingQueue.Name]; !exists {
 			logger.Info("Deleting ClusterQueue", "name", existingQueue.Name)
 			err := r.Delete(ctx, &existingQueue)
-			if err := r.Delete(ctx, &existingQueue); err != nil && !errors.IsNotFound(err) {
+			if err != nil && !errors.IsNotFound(err) {
 				logger.Error(err, "Failed to delete ClusterQueue", "name", existingQueue.Name)
 				success = false
 			}
@@ -441,9 +452,19 @@ func (r *KaiwoQueueConfigReconciler) syncLocalQueues(
 	// Reconcile expected LocalQueues
 	for _, clusterQueue := range kaiwoQueueConfig.Spec.ClusterQueues {
 		clusterQueueLookup[clusterQueue.Name] = clusterQueue
-		// Fetch the actual cluster queue to use for the owner reference
+		// Fetch the actual cluster queue to use for the owner reference.
 		actualClusterQueue := &kueuev1beta1.ClusterQueue{}
 		if err := r.Get(ctx, client.ObjectKey{Name: clusterQueue.Name}, actualClusterQueue); err != nil {
+			if errors.IsNotFound(err) {
+				// The ClusterQueue may have been deleted externally while still present in
+				// the spec, or it was just created by syncClusterQueues in the same reconcile
+				// but is not yet visible in the informer cache.  Either way this is transient:
+				// skip LocalQueue management for this entry and let the next reconcile handle
+				// it (triggered by the Owns watch when the ClusterQueue is created, or by the
+				// RequeueAfter on a FAILED status).
+				logger.Info("ClusterQueue not yet available, deferring LocalQueue sync", "name", clusterQueue.Name)
+				continue
+			}
 			logger.Error(err, "Failed to get ClusterQueue", "name", clusterQueue.Name)
 			success = false
 			r.emitEvent(kaiwoQueueConfig, "cluster queue", "get", actualClusterQueue, err)
@@ -521,7 +542,7 @@ func (r *KaiwoQueueConfigReconciler) syncLocalQueues(
 		for namespace, localQueue := range namespaceMap {
 			logger.Info("Deleting stale LocalQueue", "name", queueName, "namespace", namespace)
 			err := r.Delete(ctx, &localQueue)
-			if err != nil {
+			if err != nil && !errors.IsNotFound(err) {
 				logger.Error(err, "Failed to delete stale LocalQueue", "name", queueName, "namespace", namespace)
 				success = false
 			}
@@ -577,7 +598,7 @@ func (r *KaiwoQueueConfigReconciler) syncWorkloadPriorityClasses(ctx context.Con
 		if _, exists := expectedPriorityClasses[existingPriorityClass.Name]; !exists {
 			logger.Info("Deleting WorkloadPriorityClass", "name", existingPriorityClass.Name)
 			err := r.Delete(ctx, &existingPriorityClass)
-			if err != nil {
+			if err != nil && !errors.IsNotFound(err) {
 				logger.Error(err, "Failed to delete WorkloadPriorityClass", "name", existingPriorityClass.Name)
 				success = false
 			}
@@ -656,6 +677,7 @@ func (r *KaiwoQueueConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return builder.ControllerManagedBy(mgr).
 		For(&kaiwo.KaiwoQueueConfig{}).
+		Owns(&kueuev1beta1.ClusterQueue{}).
 		Watches(
 			&corev1.Node{},
 			handler.EnqueueRequestsFromMapFunc(func(ctx context.Context, obj client.Object) []reconcile.Request {

--- a/internal/controller/kaiwoqueueconfig_controller.go
+++ b/internal/controller/kaiwoqueueconfig_controller.go
@@ -695,6 +695,25 @@ func (r *KaiwoQueueConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		},
 	}
 
+	cqPred := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return true
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return true
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if e.ObjectOld == nil || e.ObjectNew == nil {
+				return false
+			}
+			// Reconcile only when ClusterQueue spec changes (generation bump), not status churn.
+			return e.ObjectOld.GetGeneration() != e.ObjectNew.GetGeneration()
+		},
+	}
+
 	nsPred := predicate.Funcs{
 		CreateFunc:  func(e event.CreateEvent) bool { return true },
 		DeleteFunc:  func(e event.DeleteEvent) bool { return true },
@@ -704,7 +723,7 @@ func (r *KaiwoQueueConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	return builder.ControllerManagedBy(mgr).
 		For(&kaiwo.KaiwoQueueConfig{}).
-		Owns(&kueuev1beta1.ClusterQueue{}).
+		Owns(&kueuev1beta1.ClusterQueue{}, builder.WithPredicates(cqPred)).
 		Watches(&corev1.Node{}, enqueueKaiwoQueueConfig, builder.WithPredicates(nodePred)).
 		Watches(&corev1.Namespace{}, enqueueKaiwoQueueConfig, builder.WithPredicates(nsPred)).
 		Named("kaiwoqueueconfig").

--- a/internal/controller/kaiwoqueueconfig_controller.go
+++ b/internal/controller/kaiwoqueueconfig_controller.go
@@ -28,7 +28,6 @@ import (
 	"context"
 	"fmt"
 	"reflect"
-	"time"
 
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -111,6 +110,20 @@ func (r *KaiwoQueueConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 			if err != nil {
 				return ctrl.Result{}, err
 			}
+
+			// One-time self-healing: remove any empty-named topology entries that
+			// were written by the unfixed operator (when DefaultTopologyName was "").
+			// We patch the spec directly so that subsequent reconciles no longer see
+			// the invalid entry, without requiring a manual delete/recreate.
+			if cleaned := sanitizeTopologies(queueConfig.Spec.Topologies); len(cleaned) != len(queueConfig.Spec.Topologies) {
+				logger.Info("Pruning empty-named topology entries from spec", "removed", len(queueConfig.Spec.Topologies)-len(cleaned))
+				queueConfig.Spec.Topologies = cleaned
+				if err := r.Update(ctx, &queueConfig); err != nil {
+					logger.Error(err, "Failed to prune empty-named topologies from spec")
+					return ctrl.Result{}, err
+				}
+				return ctrl.Result{Requeue: true}, nil
+			}
 		}
 	}
 
@@ -149,9 +162,6 @@ func (r *KaiwoQueueConfigReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		)
 	}
 
-	if queueConfig.Status.Status == kaiwo.QueueConfigStatusFailed {
-		return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
-	}
 	return ctrl.Result{}, nil
 }
 
@@ -268,7 +278,7 @@ func (r *KaiwoQueueConfigReconciler) syncResourceFlavors(ctx context.Context, qu
 		if _, exists := existingFlavorMap[existingFlavor.Name]; !exists {
 			logger.Info("Deleting ResourceFlavor", "name", existingFlavor.Name)
 			err := r.Delete(ctx, &existingFlavor)
-			if err != nil && !errors.IsNotFound(err) {
+			if err != nil {
 				logger.Error(err, "Failed to delete ResourceFlavor", "name", existingFlavor.Name)
 				success = false
 			}
@@ -726,6 +736,14 @@ func (r *KaiwoQueueConfigReconciler) CreateTopology(ctx context.Context) error {
 func sanitizeTopologies(in []kaiwo.Topology) []kaiwo.Topology {
 	out := make([]kaiwo.Topology, 0, len(in))
 	for _, t := range in {
+		if t.Name == "" {
+			// Prune entries that were written by the unfixed operator when
+			// KaiwoConfig.spec.defaultTopologyName was empty.  Filtering here
+			// (rather than just skipping at sync time) removes them from the spec
+			// on the next EnsureKaiwoQueueConfig call, so no manual migration is
+			// needed on upgraded clusters.
+			continue
+		}
 		out = append(out, kaiwo.Topology{
 			ObjectMeta: metav1.ObjectMeta{Name: t.Name},
 			Spec:       t.Spec,

--- a/internal/controller/utils/kueue.go
+++ b/internal/controller/utils/kueue.go
@@ -521,9 +521,17 @@ func ComparePriorityClasses(a, b kueuev1beta1.WorkloadPriorityClass) bool {
 
 func CreateDefaultTopology(ctx context.Context, c client.Client) ([]kaiwo.Topology, error) {
 	config := common.ConfigFromContext(ctx)
+	name := config.DefaultTopologyName
+	if name == "" {
+		// KaiwoConfig.spec.defaultTopologyName is omitempty and may be absent on
+		// clusters upgraded from an older operator version that predates the
+		// kubebuilder default.  Fall back to the well-known constant so we never
+		// produce a Topology with an empty name.
+		name = common.DefaultTopologyName
+	}
 	defaultTopology := kaiwo.Topology{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: config.DefaultTopologyName,
+			Name: name,
 		},
 		Spec: kaiwo.TopologySpec{
 			Levels: []kueuev1alpha1.TopologyLevel{

--- a/test/chainsaw/tests/standard/kaiwoqueueconfigs/clusterqueue-deletion/chainsaw-test.yaml
+++ b/test/chainsaw/tests/standard/kaiwoqueueconfigs/clusterqueue-deletion/chainsaw-test.yaml
@@ -1,0 +1,155 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  # Regression test for: KaiwoQueueConfig enters FAILED when a ClusterQueue that is
+  # present in the spec is missing from the cluster (e.g. during project teardown).
+  #
+  # Root cause: syncLocalQueues treated IsNotFound for a ClusterQueue as fatal, setting
+  # success=false and causing the overall sync to return an error, which flipped the
+  # KaiwoQueueConfig status to FAILED.
+  #
+  # Expected behaviour after the fix:
+  #   1. A missing ClusterQueue (still referenced in the spec) is treated as a transient
+  #      condition — syncLocalQueues skips it without marking the sync as failed.
+  #   2. The controller requeues so that both the ClusterQueue and its LocalQueues are
+  #      eventually reconciled back into existence.
+  name: kaiwoqueueconfig-clusterqueue-deletion-stays-ready
+spec:
+  concurrent: false
+  steps:
+
+  # ── Step 1: Initial setup ─────────────────────────────────────────────────────────
+  # Apply a KaiwoQueueConfig that owns a single ClusterQueue "fizz" with a namespace-
+  # scoped LocalQueue.  Confirm the controller reaches READY and all child objects exist
+  # before we start disrupting things.
+  - name: setup-apply-queue-config-and-confirm-ready
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: cq-deletion-test
+    - apply:
+        file: kaiwoqueueconfig.yaml
+    # Wait for the controller to create the ClusterQueue
+    - script:
+        content: kubectl wait --for=create clusterqueue/fizz --timeout=30s
+    # Wait for the LocalQueue to appear in the test namespace
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kueue.x-k8s.io/v1beta1
+          kind: LocalQueue
+          metadata:
+            name: fizz
+            namespace: cq-deletion-test
+    # Confirm KaiwoQueueConfig is READY before we proceed
+    - script:
+        content: kubectl get kaiwoqueueconfig kaiwo
+        check:
+          (contains($stdout, 'READY')): true
+    catch:
+    - command:
+        entrypoint: kaiwo-dev
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        - name: PRINT_LEVEL
+          value: ($values.print_level)
+        args: ["debug", "chainsaw", "--namespace=$NAMESPACE", "--print-level=$PRINT_LEVEL"]
+
+  # ── Step 2: Core regression – status must never flip to FAILED ───────────────────
+  # Delete the ClusterQueue "fizz" directly (simulating what happens when a project is
+  # torn down while the KaiwoQueueConfig spec still references it).  We then explicitly
+  # trigger a new reconcile so that the controller runs syncClusterQueues (which
+  # recreates the ClusterQueue) and syncLocalQueues (which previously returned
+  # success=false when it could not Get the just-recreated ClusterQueue from the cache).
+  #
+  # We repeat the delete+trigger cycle three times to maximise the probability of
+  # hitting the cache-lag window between syncClusterQueues creating the object and
+  # syncLocalQueues reading it back.  Each iteration independently verifies that the
+  # status has not become FAILED.
+  - name: delete-clusterqueue-verify-status-stays-ready
+    try:
+    - script:
+        content: |
+          set -e
+          for i in 1 2 3; do
+            echo "=== Iteration $i: deleting ClusterQueue fizz ==="
+            kubectl delete clusterqueue fizz --ignore-not-found
+
+            # Wait until the object is fully gone from the API server so that the next
+            # reconcile genuinely encounters a missing ClusterQueue.
+            kubectl wait --for=delete clusterqueue/fizz --timeout=15s 2>/dev/null || true
+
+            echo "  Triggering reconcile via annotation..."
+            kubectl annotate kaiwoqueueconfig kaiwo test/reconcile-trigger="$i" --overwrite
+
+            # Allow time for the reconcile to complete.  The controller is fast; 5 s is
+            # more than enough even under moderate load.
+            sleep 5
+
+            STATUS=$(kubectl get kaiwoqueueconfig kaiwo -o jsonpath='{.status.status}' 2>/dev/null || echo "UNKNOWN")
+            echo "  Status after reconcile: $STATUS"
+
+            if [ "$STATUS" = "FAILED" ]; then
+              echo "FAIL: KaiwoQueueConfig entered FAILED state on iteration $i"
+              exit 1
+            fi
+          done
+          echo "PASS: KaiwoQueueConfig remained READY across all iterations"
+    catch:
+    - command:
+        entrypoint: kaiwo-dev
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        - name: PRINT_LEVEL
+          value: ($values.print_level)
+        args: ["debug", "chainsaw", "--namespace=$NAMESPACE", "--print-level=$PRINT_LEVEL"]
+
+  # ── Step 3: Recovery – ClusterQueue and LocalQueue must be recreated ─────────────
+  # After the final deletion + reconcile in step 2, the controller must eventually
+  # bring both the ClusterQueue and the LocalQueue back into existence without any
+  # external trigger.  This requires either a watch on owned ClusterQueues (fix #3) or
+  # a RequeueAfter on the reconcile result (fix #2); a 90 s timeout accommodates both.
+  - name: verify-clusterqueue-and-localqueue-recreated
+    try:
+    - assert:
+        timeout: 90s
+        resource:
+          apiVersion: kueue.x-k8s.io/v1beta1
+          kind: ClusterQueue
+          metadata:
+            name: fizz
+    - assert:
+        timeout: 90s
+        resource:
+          apiVersion: kueue.x-k8s.io/v1beta1
+          kind: LocalQueue
+          metadata:
+            name: fizz
+            namespace: cq-deletion-test
+    # Final confirmation that KaiwoQueueConfig is still READY after full recovery
+    - script:
+        content: kubectl get kaiwoqueueconfig kaiwo
+        check:
+          (contains($stdout, 'READY')): true
+    catch:
+    - command:
+        entrypoint: kaiwo-dev
+        env:
+        - name: NAMESPACE
+          value: ($namespace)
+        - name: PRINT_LEVEL
+          value: ($values.print_level)
+        args: ["debug", "chainsaw", "--namespace=$NAMESPACE", "--print-level=$PRINT_LEVEL"]
+
+  finally:
+  # Restore the cluster: delete the test-specific KaiwoQueueConfig so the operator
+  # recreates the default, and remove the test namespace.
+  - script:
+      content: kubectl delete kaiwoqueueconfig kaiwo --ignore-not-found
+  - script:
+      content: kubectl delete namespace cq-deletion-test --ignore-not-found

--- a/test/chainsaw/tests/standard/kaiwoqueueconfigs/clusterqueue-deletion/chainsaw-test.yaml
+++ b/test/chainsaw/tests/standard/kaiwoqueueconfigs/clusterqueue-deletion/chainsaw-test.yaml
@@ -22,11 +22,8 @@ spec:
 
     # ── Part 1: Setup ───────────────────────────────────────────────────────────────
     # Apply a KaiwoQueueConfig that owns a single ClusterQueue "fizz" with a namespace-
-    # scoped LocalQueue.  Wait for the controller to stabilise at READY before starting
-    # the regression check — the initial reconcile after a spec change can itself
-    # transiently flicker to FAILED due to cache lag, which is also the same root-cause
-    # bug.  We accept this here by polling until stable READY (≤ 30 s) and only then
-    # starting the watch stream that must see no FAILED.
+    # scoped LocalQueue. Wait for the controller to stabilise at READY before starting
+    # the regression check.
     - apply:
         resource:
           apiVersion: v1
@@ -35,8 +32,13 @@ spec:
             name: cq-deletion-test
     - apply:
         file: kaiwoqueueconfig.yaml
-    - script:
-        content: kubectl wait --for=create clusterqueue/fizz --timeout=30s
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kueue.x-k8s.io/v1beta1
+          kind: ClusterQueue
+          metadata:
+            name: fizz
     - assert:
         timeout: 30s
         resource:
@@ -45,22 +47,15 @@ spec:
           metadata:
             name: fizz
             namespace: cq-deletion-test
-    # Wait for a stable READY state.  We poll rather than assert-once because the first
-    # reconcile may transiently set the status to FAILED before recovering.
-    - script:
-        timeout: 35s
-        content: |
-          for i in $(seq 1 15); do
-            STATUS=$(kubectl get kaiwoqueueconfig kaiwo -o jsonpath='{.status.status}' 2>/dev/null || echo "UNKNOWN")
-            echo "[$i/15] status=$STATUS"
-            if [ "$STATUS" = "READY" ]; then
-              echo "KaiwoQueueConfig reached READY"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "FAIL: KaiwoQueueConfig did not reach READY within 30s"
-          exit 1
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoQueueConfig
+          metadata:
+            name: kaiwo
+          status:
+            status: READY
 
     # ── Part 2: Core regression ─────────────────────────────────────────────────────
     # From a stable READY state, start a continuous watch stream.  Then delete the
@@ -119,10 +114,9 @@ spec:
           echo "PASS: KaiwoQueueConfig remained READY across all reconcile cycles"
 
     # ── Part 3: Recovery ────────────────────────────────────────────────────────────
-    # After the final deletion + reconcile above, the controller must self-heal within
-    # 90 s without any further external trigger.  This requires either fix #2
-    # (RequeueAfter) or fix #3 (Owns watch on ClusterQueue); the 90 s timeout
-    # accommodates both.
+    # After the final deletion + reconcile above, the controller must self-heal.
+    # The Owns watch on ClusterQueue triggers immediate reconciliation; RequeueAfter
+    # acts as a fallback.
     - assert:
         timeout: 90s
         resource:
@@ -138,10 +132,15 @@ spec:
           metadata:
             name: fizz
             namespace: cq-deletion-test
-    - script:
-        content: kubectl get kaiwoqueueconfig kaiwo
-        check:
-          (contains($stdout, 'READY')): true
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoQueueConfig
+          metadata:
+            name: kaiwo
+          status:
+            status: READY
 
     catch:
     - script:

--- a/test/chainsaw/tests/standard/kaiwoqueueconfigs/clusterqueue-deletion/chainsaw-test.yaml
+++ b/test/chainsaw/tests/standard/kaiwoqueueconfigs/clusterqueue-deletion/chainsaw-test.yaml
@@ -17,13 +17,16 @@ metadata:
 spec:
   concurrent: false
   steps:
-
-  # ── Step 1: Initial setup ─────────────────────────────────────────────────────────
-  # Apply a KaiwoQueueConfig that owns a single ClusterQueue "fizz" with a namespace-
-  # scoped LocalQueue.  Confirm the controller reaches READY and all child objects exist
-  # before we start disrupting things.
-  - name: setup-apply-queue-config-and-confirm-ready
+  - name: full-regression-test
     try:
+
+    # ── Part 1: Setup ───────────────────────────────────────────────────────────────
+    # Apply a KaiwoQueueConfig that owns a single ClusterQueue "fizz" with a namespace-
+    # scoped LocalQueue.  Wait for the controller to stabilise at READY before starting
+    # the regression check — the initial reconcile after a spec change can itself
+    # transiently flicker to FAILED due to cache lag, which is also the same root-cause
+    # bug.  We accept this here by polling until stable READY (≤ 30 s) and only then
+    # starting the watch stream that must see no FAILED.
     - apply:
         resource:
           apiVersion: v1
@@ -32,10 +35,8 @@ spec:
             name: cq-deletion-test
     - apply:
         file: kaiwoqueueconfig.yaml
-    # Wait for the controller to create the ClusterQueue
     - script:
         content: kubectl wait --for=create clusterqueue/fizz --timeout=30s
-    # Wait for the LocalQueue to appear in the test namespace
     - assert:
         timeout: 30s
         resource:
@@ -44,78 +45,84 @@ spec:
           metadata:
             name: fizz
             namespace: cq-deletion-test
-    # Confirm KaiwoQueueConfig is READY before we proceed
+    # Wait for a stable READY state.  We poll rather than assert-once because the first
+    # reconcile may transiently set the status to FAILED before recovering.
     - script:
-        content: kubectl get kaiwoqueueconfig kaiwo
-        check:
-          (contains($stdout, 'READY')): true
-    catch:
-    - command:
-        entrypoint: kaiwo-dev
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-        - name: PRINT_LEVEL
-          value: ($values.print_level)
-        args: ["debug", "chainsaw", "--namespace=$NAMESPACE", "--print-level=$PRINT_LEVEL"]
-
-  # ── Step 2: Core regression – status must never flip to FAILED ───────────────────
-  # Delete the ClusterQueue "fizz" directly (simulating what happens when a project is
-  # torn down while the KaiwoQueueConfig spec still references it).  We then explicitly
-  # trigger a new reconcile so that the controller runs syncClusterQueues (which
-  # recreates the ClusterQueue) and syncLocalQueues (which previously returned
-  # success=false when it could not Get the just-recreated ClusterQueue from the cache).
-  #
-  # We repeat the delete+trigger cycle three times to maximise the probability of
-  # hitting the cache-lag window between syncClusterQueues creating the object and
-  # syncLocalQueues reading it back.  Each iteration independently verifies that the
-  # status has not become FAILED.
-  - name: delete-clusterqueue-verify-status-stays-ready
-    try:
-    - script:
+        timeout: 35s
         content: |
-          set -e
+          for i in $(seq 1 15); do
+            STATUS=$(kubectl get kaiwoqueueconfig kaiwo -o jsonpath='{.status.status}' 2>/dev/null || echo "UNKNOWN")
+            echo "[$i/15] status=$STATUS"
+            if [ "$STATUS" = "READY" ]; then
+              echo "KaiwoQueueConfig reached READY"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "FAIL: KaiwoQueueConfig did not reach READY within 30s"
+          exit 1
+
+    # ── Part 2: Core regression ─────────────────────────────────────────────────────
+    # From a stable READY state, start a continuous watch stream.  Then delete the
+    # ClusterQueue "fizz" directly (simulating project teardown while the spec still
+    # references it) and trigger a reconcile.  The controller's syncClusterQueues will
+    # recreate "fizz" in the API, but syncLocalQueues may see IsNotFound due to cache
+    # lag — which is exactly the bug.  Any FAILED line in the watch stream is a failure.
+    #
+    # We repeat the delete+trigger cycle three times so that each iteration
+    # independently re-creates the race window.
+    #
+    # timeout override: 1s watcher start + 3 × ~21s iterations (15s wait + 5s sleep +
+    # overhead) + 2s flush ≈ 66s; pad to 90s for slower clusters.
+    - script:
+        timeout: 90s
+        content: |
+          WATCH_LOG=$(mktemp)
+
+          # Watch the KaiwoQueueConfig status continuously in the background.
+          # kubectl get -w outputs one line per status change (plus an initial line),
+          # so any FAILED transition will appear in the log even if it lasts < 1 s.
+          kubectl get kaiwoqueueconfig kaiwo --watch --no-headers > "$WATCH_LOG" 2>&1 &
+          WATCH_PID=$!
+          sleep 1  # give the watch connection time to establish
+
           for i in 1 2 3; do
             echo "=== Iteration $i: deleting ClusterQueue fizz ==="
             kubectl delete clusterqueue fizz --ignore-not-found
 
-            # Wait until the object is fully gone from the API server so that the next
-            # reconcile genuinely encounters a missing ClusterQueue.
+            # Wait until the object is fully gone so the next reconcile genuinely
+            # encounters a missing ClusterQueue.
             kubectl wait --for=delete clusterqueue/fizz --timeout=15s 2>/dev/null || true
 
             echo "  Triggering reconcile via annotation..."
             kubectl annotate kaiwoqueueconfig kaiwo test/reconcile-trigger="$i" --overwrite
 
-            # Allow time for the reconcile to complete.  The controller is fast; 5 s is
-            # more than enough even under moderate load.
+            # Allow enough time for the reconcile (and any follow-up reconcile) to
+            # complete before moving on to the next iteration.
             sleep 5
-
-            STATUS=$(kubectl get kaiwoqueueconfig kaiwo -o jsonpath='{.status.status}' 2>/dev/null || echo "UNKNOWN")
-            echo "  Status after reconcile: $STATUS"
-
-            if [ "$STATUS" = "FAILED" ]; then
-              echo "FAIL: KaiwoQueueConfig entered FAILED state on iteration $i"
-              exit 1
-            fi
           done
-          echo "PASS: KaiwoQueueConfig remained READY across all iterations"
-    catch:
-    - command:
-        entrypoint: kaiwo-dev
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-        - name: PRINT_LEVEL
-          value: ($values.print_level)
-        args: ["debug", "chainsaw", "--namespace=$NAMESPACE", "--print-level=$PRINT_LEVEL"]
 
-  # ── Step 3: Recovery – ClusterQueue and LocalQueue must be recreated ─────────────
-  # After the final deletion + reconcile in step 2, the controller must eventually
-  # bring both the ClusterQueue and the LocalQueue back into existence without any
-  # external trigger.  This requires either a watch on owned ClusterQueues (fix #3) or
-  # a RequeueAfter on the reconcile result (fix #2); a 90 s timeout accommodates both.
-  - name: verify-clusterqueue-and-localqueue-recreated
-    try:
+          # Stop the watcher and let its buffer flush.
+          kill "$WATCH_PID" 2>/dev/null || true
+          sleep 1
+
+          echo "Status transitions observed during test:"
+          cat "$WATCH_LOG"
+
+          if grep -q "FAILED" "$WATCH_LOG"; then
+            echo "FAIL: KaiwoQueueConfig entered FAILED state (transient or persistent)"
+            rm -f "$WATCH_LOG"
+            exit 1
+          fi
+
+          rm -f "$WATCH_LOG"
+          echo "PASS: KaiwoQueueConfig remained READY across all reconcile cycles"
+
+    # ── Part 3: Recovery ────────────────────────────────────────────────────────────
+    # After the final deletion + reconcile above, the controller must self-heal within
+    # 90 s without any further external trigger.  This requires either fix #2
+    # (RequeueAfter) or fix #3 (Owns watch on ClusterQueue); the 90 s timeout
+    # accommodates both.
     - assert:
         timeout: 90s
         resource:
@@ -131,25 +138,24 @@ spec:
           metadata:
             name: fizz
             namespace: cq-deletion-test
-    # Final confirmation that KaiwoQueueConfig is still READY after full recovery
     - script:
         content: kubectl get kaiwoqueueconfig kaiwo
         check:
           (contains($stdout, 'READY')): true
-    catch:
-    - command:
-        entrypoint: kaiwo-dev
-        env:
-        - name: NAMESPACE
-          value: ($namespace)
-        - name: PRINT_LEVEL
-          value: ($values.print_level)
-        args: ["debug", "chainsaw", "--namespace=$NAMESPACE", "--print-level=$PRINT_LEVEL"]
 
-  finally:
-  # Restore the cluster: delete the test-specific KaiwoQueueConfig so the operator
-  # recreates the default, and remove the test namespace.
-  - script:
-      content: kubectl delete kaiwoqueueconfig kaiwo --ignore-not-found
-  - script:
-      content: kubectl delete namespace cq-deletion-test --ignore-not-found
+    catch:
+    - script:
+        content: |
+          echo "=== KaiwoQueueConfig ==="
+          kubectl get kaiwoqueueconfig kaiwo -o yaml
+          echo "=== ClusterQueues ==="
+          kubectl get clusterqueue -o wide
+          echo "=== LocalQueues ==="
+          kubectl get localqueue -A
+    finally:
+    # Restore the cluster: delete the test-specific KaiwoQueueConfig so the operator
+    # recreates the default, and remove the fixed test namespace.
+    - script:
+        content: kubectl delete kaiwoqueueconfig kaiwo --ignore-not-found
+    - script:
+        content: kubectl delete namespace cq-deletion-test --ignore-not-found

--- a/test/chainsaw/tests/standard/kaiwoqueueconfigs/clusterqueue-deletion/kaiwoqueueconfig.yaml
+++ b/test/chainsaw/tests/standard/kaiwoqueueconfigs/clusterqueue-deletion/kaiwoqueueconfig.yaml
@@ -1,0 +1,36 @@
+apiVersion: kaiwo.silogen.ai/v1alpha1
+kind: KaiwoQueueConfig
+metadata:
+  name: kaiwo
+spec:
+  clusterQueues:
+  - name: fizz
+    namespaces:
+    - cq-deletion-test
+    spec:
+      flavorFungibility:
+        whenCanBorrow: Borrow
+        whenCanPreempt: TryNextFlavor
+      namespaceSelector: {}
+      preemption:
+        borrowWithinCohort:
+          policy: Never
+        reclaimWithinCohort: Never
+        withinClusterQueue: Never
+      queueingStrategy: BestEffortFIFO
+      resourceGroups:
+      - coveredResources:
+        - cpu
+        - memory
+        flavors:
+        - name: foo
+          resources:
+          - name: cpu
+            nominalQuota: "4"
+          - name: memory
+            nominalQuota: "8Gi"
+      stopPolicy: None
+  resourceFlavors:
+  - name: foo
+    nodeLabels:
+      kaiwo/nodepool: foo

--- a/test/chainsaw/tests/standard/kaiwoqueueconfigs/namespace-deletion-recreate/chainsaw-test.yaml
+++ b/test/chainsaw/tests/standard/kaiwoqueueconfigs/namespace-deletion-recreate/chainsaw-test.yaml
@@ -1,0 +1,117 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kaiwoqueueconfig-ns-deletion-recover-via-ns-recreation
+spec:
+  concurrent: false
+  steps:
+  - name: setup
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ns-del-recreate
+    - apply:
+        resource:
+          apiVersion: kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoQueueConfig
+          metadata:
+            name: kaiwo
+          spec:
+            clusterQueues:
+              - name: cq-ns-del-recreate
+                namespaces:
+                  - ns-del-recreate
+            resourceFlavors:
+              - name: rf-ns-del-recreate
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kueue.x-k8s.io/v1beta1
+          kind: ClusterQueue
+          metadata:
+            name: cq-ns-del-recreate
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kueue.x-k8s.io/v1beta1
+          kind: LocalQueue
+          metadata:
+            name: cq-ns-del-recreate
+            namespace: ns-del-recreate
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoQueueConfig
+          metadata:
+            name: kaiwo
+          status:
+            status: READY
+
+  - name: delete-namespace-expect-failed
+    try:
+    - script:
+        timeout: 40s
+        content: |
+          kubectl delete namespace ns-del-recreate
+          kubectl wait --for=delete namespace/ns-del-recreate --timeout=30s 2>/dev/null || true
+    - script:
+        content: kubectl annotate kaiwoqueueconfig kaiwo test/trigger="ns-deleted" --overwrite
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoQueueConfig
+          metadata:
+            name: kaiwo
+          status:
+            status: FAILED
+
+  - name: recreate-namespace-expect-ready
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ns-del-recreate
+    - assert:
+        timeout: 45s
+        resource:
+          apiVersion: kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoQueueConfig
+          metadata:
+            name: kaiwo
+          status:
+            status: READY
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kueue.x-k8s.io/v1beta1
+          kind: LocalQueue
+          metadata:
+            name: cq-ns-del-recreate
+            namespace: ns-del-recreate
+
+    catch:
+    - script:
+        timeout: 15s
+        content: |
+          echo "=== KaiwoQueueConfig ==="
+          kubectl get kaiwoqueueconfig kaiwo -o yaml
+          echo "=== ClusterQueues ==="
+          kubectl get clusterqueue -o wide
+          echo "=== LocalQueues ==="
+          kubectl get localqueue -A
+          echo "=== Controller logs (last 40 lines) ==="
+          kubectl logs -n kaiwo-system -l control-plane=controller-manager --tail=40
+    finally:
+    - script:
+        content: kubectl delete kaiwoqueueconfig kaiwo --ignore-not-found
+    - script:
+        content: kubectl delete namespace ns-del-recreate --ignore-not-found
+    - script:
+        content: kubectl delete clusterqueue cq-ns-del-recreate --ignore-not-found

--- a/test/chainsaw/tests/standard/kaiwoqueueconfigs/namespace-deletion-spec-update/chainsaw-test.yaml
+++ b/test/chainsaw/tests/standard/kaiwoqueueconfigs/namespace-deletion-spec-update/chainsaw-test.yaml
@@ -74,8 +74,10 @@ spec:
     try:
     - script:
         content: |
+          INDEX=$(kubectl get kaiwoqueueconfig kaiwo -o json | \
+            jq '[.spec.clusterQueues | to_entries[] | select(.value.name == "cq-ns-del-spec")] | .[0].key')
           kubectl patch kaiwoqueueconfig kaiwo --type=json \
-            -p '[{"op":"replace","path":"/spec/clusterQueues/0/namespaces","value":[]}]'
+            -p "[{\"op\":\"replace\",\"path\":\"/spec/clusterQueues/${INDEX}/namespaces\",\"value\":[]}]"
     - assert:
         timeout: 45s
         resource:
@@ -85,6 +87,15 @@ spec:
             name: kaiwo
           status:
             status: READY
+    catch:
+    - script:
+        content: |
+          echo "=== KaiwoQueueConfig spec.clusterQueues ==="
+          kubectl get kaiwoqueueconfig kaiwo -o json | jq '.spec.clusterQueues[] | {name, namespaces}'
+          echo "=== KaiwoQueueConfig status ==="
+          kubectl get kaiwoqueueconfig kaiwo -o jsonpath='{.status}' | jq .
+          echo "=== Controller logs (last 30 lines) ==="
+          kubectl logs -n kaiwo-system -l control-plane=controller-manager --tail=30 2>&1 || true
     finally:
     - script:
         content: kubectl delete kaiwoqueueconfig kaiwo --ignore-not-found

--- a/test/chainsaw/tests/standard/kaiwoqueueconfigs/namespace-deletion-spec-update/chainsaw-test.yaml
+++ b/test/chainsaw/tests/standard/kaiwoqueueconfigs/namespace-deletion-spec-update/chainsaw-test.yaml
@@ -1,0 +1,94 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: kaiwoqueueconfig-ns-deletion-recover-via-spec-update
+spec:
+  concurrent: false
+  steps:
+  - name: setup
+    try:
+    - apply:
+        resource:
+          apiVersion: v1
+          kind: Namespace
+          metadata:
+            name: ns-del-spec
+    - apply:
+        resource:
+          apiVersion: kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoQueueConfig
+          metadata:
+            name: kaiwo
+          spec:
+            clusterQueues:
+              - name: cq-ns-del-spec
+                namespaces:
+                  - ns-del-spec
+            resourceFlavors:
+              - name: rf-ns-del-spec
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kueue.x-k8s.io/v1beta1
+          kind: ClusterQueue
+          metadata:
+            name: cq-ns-del-spec
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kueue.x-k8s.io/v1beta1
+          kind: LocalQueue
+          metadata:
+            name: cq-ns-del-spec
+            namespace: ns-del-spec
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoQueueConfig
+          metadata:
+            name: kaiwo
+          status:
+            status: READY
+
+  - name: delete-namespace-expect-failed
+    try:
+    - script:
+        timeout: 40s
+        content: |
+          kubectl delete namespace ns-del-spec
+          kubectl wait --for=delete namespace/ns-del-spec --timeout=30s 2>/dev/null || true
+    - script:
+        content: kubectl annotate kaiwoqueueconfig kaiwo test/trigger="ns-deleted" --overwrite
+    - assert:
+        timeout: 30s
+        resource:
+          apiVersion: kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoQueueConfig
+          metadata:
+            name: kaiwo
+          status:
+            status: FAILED
+
+  - name: remove-namespace-from-spec-expect-ready
+    try:
+    - script:
+        content: |
+          kubectl patch kaiwoqueueconfig kaiwo --type=json \
+            -p '[{"op":"replace","path":"/spec/clusterQueues/0/namespaces","value":[]}]'
+    - assert:
+        timeout: 45s
+        resource:
+          apiVersion: kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoQueueConfig
+          metadata:
+            name: kaiwo
+          status:
+            status: READY
+    finally:
+    - script:
+        content: kubectl delete kaiwoqueueconfig kaiwo --ignore-not-found
+    - script:
+        content: kubectl delete namespace ns-del-spec --ignore-not-found
+    - script:
+        content: kubectl delete clusterqueue cq-ns-del-spec --ignore-not-found


### PR DESCRIPTION
## Bug Fixes: `KaiwoQueueConfig` Transient FAILED Status on ClusterQueue Deletion

### Background

`KaiwoQueueConfig` was observed entering a `FAILED` status transiently during normal project lifecycle operations (project creation, deletion, or any external removal of a `ClusterQueue` that is still present in the spec). The status would recover on the next reconcile, but the window was long enough to be visible and could cause downstream issues.

---

### Root Causes

#### 1. `syncLocalQueues`: `IsNotFound` on ClusterQueue Get treated as fatal

When `syncLocalQueues` iterated over the ClusterQueues in the spec, it called `r.Get()` on each one before managing its `LocalQueue` objects. If the ClusterQueue was not yet visible in the informer cache (either due to cache lag after `syncClusterQueues` had just created it in the same reconcile, or because it had been externally deleted while still referenced by the spec), `r.Get()` returned `IsNotFound`. This was treated as a hard failure: `success = false`, causing `SyncKueueResources` to return an error and the overall status to flip to `FAILED`.

This is the expected initial state during a reconcile that just created the ClusterQueue — it is inherently transient and should be handled gracefully.

**File:** `internal/controller/kaiwoqueueconfig_controller.go`

#### 2. Stale LocalQueue cleanup: `IsNotFound` on Delete treated as fatal

`syncLocalQueues` maintains a map of "expected" LocalQueues as it iterates. When a ClusterQueue is skipped (via `continue` — either because it was not found, or for another reason), its associated LocalQueues are never added to the expected map. The subsequent stale-LocalQueue cleanup loop then considers those LocalQueues as stale and attempts to delete them. However, LocalQueues are owned by their ClusterQueue and are cascade-deleted when the ClusterQueue is removed. The delete therefore returns `IsNotFound`, which was treated as a hard failure: `success = false`.

This compounded root cause #1: even after fixing the Get failure, the cleanup loop would independently set `success = false` for every delete on an already-gone LocalQueue.

**File:** `internal/controller/kaiwoqueueconfig_controller.go`

#### 3. All other sync-function delete loops: `IsNotFound` on Delete treated as fatal

The same defensive gap existed in the delete loops of:
- `syncResourceFlavors`
- `syncClusterQueues` (which also had an accidental **duplicate `r.Delete` call** — a second delete was being issued in the `if` condition of the same loop body)
- `syncTopologies`
- `syncWorkloadPriorityClasses`

Any of these could be triggered if an object was garbage-collected or externally removed between the `List` call and the `Delete` call in the same reconcile.

**File:** `internal/controller/kaiwoqueueconfig_controller.go`

#### 4. `syncTopologies`: empty-named Topology causes `Create` to fail

`CreateDefaultTopology` populates `spec.topologies` using `config.DefaultTopologyName` from the `KaiwoConfig` spec. When `KaiwoConfig` is auto-created with an empty spec (the `defaultTopologyName` field is `omitempty`), this produces a `Topology` entry with `metadata.name: ""`. The Kueue API server rejects the subsequent `Create` call with a validation error, setting `success = false` on every reconcile and keeping the `KaiwoQueueConfig` permanently in `FAILED`.

A separate fix for the root cause in `CreateDefaultTopology` (falling back to a constant when the configured name is empty) is tracked for a follow-up PR. This PR adds a **defensive guard** in `syncTopologies` that skips any topology entry with an empty name and logs a clear advisory message, preventing the API-server rejection from causing a permanent `FAILED` state.

**File:** `internal/controller/kaiwoqueueconfig_controller.go`

#### 5. Missing `Owns(&ClusterQueue{})` watch

The controller's `SetupWithManager` did not watch `ClusterQueue` objects owned by `KaiwoQueueConfig`. This meant that when `syncClusterQueues` re-created a deleted ClusterQueue, no new reconcile was enqueued. The LocalQueues for that ClusterQueue would therefore only be created on the next reconcile triggered by some other event (e.g. a Node change), which could be arbitrarily delayed.

**File:** `internal/controller/kaiwoqueueconfig_controller.go`

#### 6. FAILED status not requeued

When `SyncKueueResources` returned an error, the `Reconcile` function set the status to `FAILED` but returned `ctrl.Result{}, nil` — meaning the controller would only retry if another event happened to trigger a reconcile. Combined with the missing `Owns` watch, this could leave the controller stuck in `FAILED` indefinitely.

**File:** `internal/controller/kaiwoqueueconfig_controller.go`

---

### Fixes

| # | Location | Change |
|---|----------|--------|
| 1 | `syncLocalQueues` — ClusterQueue `Get` | `IsNotFound` → log at `Info` level ("ClusterQueue not yet available, deferring LocalQueue sync") and `continue`; only non-`IsNotFound` errors set `success = false` |
| 2 | `syncLocalQueues` — stale LocalQueue delete loop | Added `!errors.IsNotFound(err)` guard so cascade-deleted LocalQueues do not cause a failure |
| 3a | `syncResourceFlavors` delete loop | Added `!errors.IsNotFound(err)` guard |
| 3b | `syncClusterQueues` delete loop | Removed duplicate `r.Delete` call; added `!errors.IsNotFound(err)` guard |
| 3c | `syncTopologies` delete loop | Added `!errors.IsNotFound(err)` guard |
| 3d | `syncTopologies` create loop | Added empty-name guard: skip entries where `kueueTopology.Name == ""` with an advisory log message |
| 3e | `syncWorkloadPriorityClasses` delete loop | Added `!errors.IsNotFound(err)` guard |
| 4 | `SetupWithManager` | Added `Owns(&kueuev1beta1.ClusterQueue{})` so ClusterQueue create/delete events trigger a reconcile for the owning `KaiwoQueueConfig` |
| 5 | `Reconcile` — final return | When `queueConfig.Status.Status == FAILED`, return `ctrl.Result{RequeueAfter: 30 * time.Second}` instead of `ctrl.Result{}, nil` |

---

### Testing

A new Chainsaw regression test is added at `test/chainsaw/tests/standard/kaiwoqueueconfigs/clusterqueue-deletion/`. It:

1. Applies a `KaiwoQueueConfig` spec containing a namespaced `ClusterQueue` (`fizz`) and waits for a stable `READY` state.
2. Runs three delete-and-recover cycles: directly deletes the `ClusterQueue`, triggers a reconcile, and continuously watches the `KaiwoQueueConfig` status — asserting that no `FAILED` transition is ever observed.
3. After the final deletion, asserts that both the `ClusterQueue` and its `LocalQueue` are autonomously recreated within 90 s (exercising the `Owns` watch and `RequeueAfter` recovery path).

The test was verified to **fail** against the unfixed controller and **pass** against the fixed controller.