### PR TITLE
add back rbac permissions for GpuWorkload to list/delete AIMServices

### DIFF
--- a/chart/rbac-resources.yaml
+++ b/chart/rbac-resources.yaml
@@ -34,6 +34,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - aim.eai.amd.com
+  - aim.silogen.ai
+  resources:
+  - aimservices
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/chart/rbac-resources.yaml
+++ b/chart/rbac-resources.yaml
@@ -35,7 +35,6 @@ rules:
   - watch
 - apiGroups:
   - aim.eai.amd.com
-  - aim.silogen.ai
   resources:
   - aimservices
   verbs:

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -34,6 +34,15 @@ rules:
   - update
   - watch
 - apiGroups:
+  - aim.eai.amd.com
+  - aim.silogen.ai
+  resources:
+  - aimservices
+  verbs:
+  - delete
+  - get
+  - list
+- apiGroups:
   - apiextensions.k8s.io
   resources:
   - customresourcedefinitions

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -35,7 +35,6 @@ rules:
   - watch
 - apiGroups:
   - aim.eai.amd.com
-  - aim.silogen.ai
   resources:
   - aimservices
   verbs:

--- a/internal/controller/gpuworkload_controller.go
+++ b/internal/controller/gpuworkload_controller.go
@@ -100,6 +100,8 @@ func IsGpuPreemptionEnabled() bool {
 // +kubebuilder:rbac:groups=batch,resources=jobs,verbs=get;list;delete
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets;statefulsets,verbs=get;list;delete
 // +kubebuilder:rbac:groups=ray.io,resources=rayjobs;rayservices;rayclusters,verbs=get;list;delete
+// +kubebuilder:rbac:groups=aim.eai.amd.com,resources=aimservices,verbs=get;list;delete
+// +kubebuilder:rbac:groups=aim.silogen.ai,resources=aimservices,verbs=get;list;delete
 // +kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers,verbs=get;list;delete
 // +kubebuilder:rbac:groups=kaiwo.silogen.ai,resources=kaiwojobs;kaiwoservices,verbs=get;list;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update

--- a/internal/controller/gpuworkload_controller.go
+++ b/internal/controller/gpuworkload_controller.go
@@ -101,7 +101,6 @@ func IsGpuPreemptionEnabled() bool {
 // +kubebuilder:rbac:groups=apps,resources=deployments;replicasets;statefulsets,verbs=get;list;delete
 // +kubebuilder:rbac:groups=ray.io,resources=rayjobs;rayservices;rayclusters,verbs=get;list;delete
 // +kubebuilder:rbac:groups=aim.eai.amd.com,resources=aimservices,verbs=get;list;delete
-// +kubebuilder:rbac:groups=aim.silogen.ai,resources=aimservices,verbs=get;list;delete
 // +kubebuilder:rbac:groups=workload.codeflare.dev,resources=appwrappers,verbs=get;list;delete
 // +kubebuilder:rbac:groups=kaiwo.silogen.ai,resources=kaiwojobs;kaiwoservices,verbs=get;list;delete
 // +kubebuilder:rbac:groups=coordination.k8s.io,resources=leases,verbs=get;list;watch;create;update


### PR DESCRIPTION
# Description

PR adds back missing RBAC permissions for GpuWorkload to list/delete AIMServices

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [x] My code follows the style guidelines of this project. See [contributing-guidelines.md](./../contributing-guidelines.md)
- [ ] Existing workload examples run to completion after my changes (if applicable)
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes