### PR TITLE
Build CRDs as OCI image

### DIFF
--- a/.github/workflows/compile-release.yaml
+++ b/.github/workflows/compile-release.yaml
@@ -75,10 +75,10 @@ jobs:
 
 
     - name: Push Helm chart to OCI registry
-      run: make helm-push-oci TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }} IMG=ghcr.io/${{ github.repository_owner }}/kaiwo-operator-chart:${{ env.VERSION }}
+      run: make helm-push-oci TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }} CHART_OCI_OWNER=${{ github.repository_owner }}
 
     - name: Push CRDs chart to OCI registry
-      run: make crds-push-oci CHART_VERSION=${{ env.VERSION }} IMG=ghcr.io/${{ github.repository_owner }}/kaiwo-operator-crds:${{ env.VERSION }}
+      run: make crds-push-oci CHART_VERSION=${{ env.VERSION }} CHART_OCI_OWNER=${{ github.repository_owner }}
 
 
     - name: Upload install.yaml artifact
@@ -121,7 +121,8 @@ jobs:
 
            ### If using Helm - Install CRDs first
           ```bash
-          kubectl apply -f https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/crds.yaml
+           helm install kaiwo oci://ghcr.io/${{ github.repository_owner }}/kaiwo-crds-chart \
+            --version ${{ env.VERSION }}
           ```
 
           ### Helm Install (from GitHub Releases)
@@ -132,7 +133,7 @@ jobs:
 
           ### Helm Install (from OCI Registry)
           ```bash
-          helm install kaiwo oci://ghcr.io/${{ github.repository_owner }}/charts/kaiwo-operator \
+          helm install kaiwo oci://ghcr.io/${{ github.repository_owner }}/kaiwo-operator-chart \
             --version ${{ env.VERSION }} --namespace kaiwo-system --create-namespace
           ```
 

--- a/.github/workflows/compile-release.yaml
+++ b/.github/workflows/compile-release.yaml
@@ -64,7 +64,7 @@ jobs:
 
     - name: Compile CRDs to a single manifest
       run: |
-        kustomize build config/crd > crds.yaml
+        make crds
 
     - name: Package CRDs as Helm chart
       run: |

--- a/.github/workflows/compile-release.yaml
+++ b/.github/workflows/compile-release.yaml
@@ -62,14 +62,24 @@ jobs:
       run: |
         make helm-release TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }}
 
-    - name: Build CRDs
+    - name: Compile CRDs to a single manifest
       run: |
         kustomize build config/crd > crds.yaml
 
-    - name: Push Helm chart to OCI registry
+    - name: Package CRDs as Helm chart
       run: |
-        echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u $GITHUB_ACTOR --password-stdin
-        make helm-push-oci TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }}
+        make crds-package CHART_VERSION=${env.VERSION} TAG=${env.VERSION}
+
+    - name: Log in to GHCR (Helm/OCI)
+      run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u $GITHUB_ACTOR --password-stdin
+
+
+    - name: Push Helm chart to OCI registry
+      run: make helm-push-oci TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }}
+
+    - name: Push CRDs chart to OCI registry
+      run: make crds-push-oci CHART_VERSION=${env.VERSION} CHART_OCI_OWNER=${{ github.repository_owner }}
+
 
     - name: Upload install.yaml artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/compile-release.yaml
+++ b/.github/workflows/compile-release.yaml
@@ -91,7 +91,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: helm-chart
-        path: dist/kaiwo-operator-*.tgz
+        path: dist/kaiwo-operator-chart-*.tgz
 
     - name: Upload CRDs artifact
       uses: actions/upload-artifact@v4
@@ -107,7 +107,7 @@ jobs:
           workloads.zip
           install.yaml
           crds.yaml
-          dist/kaiwo-operator-*.tgz
+          dist/kaiwo-operator-chart-*.tgz
         token: '${{ secrets.GITHUB_TOKEN }}'
         draft: true
         prerelease: true
@@ -119,16 +119,16 @@ jobs:
           kubectl apply -f https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/install.yaml --server-side
           ```
 
-           ### If using Helm - Install CRDs first
+          ### If using Helm - Install CRDs first
           ```bash
-           helm install kaiwo oci://ghcr.io/${{ github.repository_owner }}/kaiwo-crds-chart \
+          helm install kaiwo-crds oci://ghcr.io/${{ github.repository_owner }}/kaiwo-crds-chart \
             --version ${{ env.VERSION }}
           ```
 
           ### Helm Install (from GitHub Releases)
           ```bash
-          curl -L https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/kaiwo-operator-${{ env.VERSION }}.tgz -o kaiwo-operator.tgz
-          helm install kaiwo kaiwo-operator.tgz --namespace kaiwo-system --create-namespace
+          curl -L https://github.com/${{ github.repository }}/releases/download/${{ env.VERSION }}/kaiwo-operator-chart-${{ env.VERSION }}.tgz -o kaiwo-operator-chart.tgz
+          helm install kaiwo kaiwo-operator-chart.tgz --namespace kaiwo-system --create-namespace
           ```
 
           ### Helm Install (from OCI Registry)

--- a/.github/workflows/compile-release.yaml
+++ b/.github/workflows/compile-release.yaml
@@ -68,7 +68,7 @@ jobs:
 
     - name: Package CRDs as Helm chart
       run: |
-        make crds-package CHART_VERSION=${env.VERSION} TAG=${env.VERSION}
+        make crds-package CHART_VERSION=${{ env.VERSION }} TAG=${{ env.VERSION }}
 
     - name: Log in to GHCR (Helm/OCI)
       run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u $GITHUB_ACTOR --password-stdin
@@ -78,7 +78,7 @@ jobs:
       run: make helm-push-oci TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }}
 
     - name: Push CRDs chart to OCI registry
-      run: make crds-push-oci CHART_VERSION=${env.VERSION} CHART_OCI_OWNER=${{ github.repository_owner }}
+      run: make crds-push-oci CHART_VERSION=${{ env.VERSION }} CHART_OCI_OWNER=${{ github.repository_owner }}
 
 
     - name: Upload install.yaml artifact

--- a/.github/workflows/compile-release.yaml
+++ b/.github/workflows/compile-release.yaml
@@ -78,7 +78,7 @@ jobs:
       run: make helm-push-oci TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }} CHART_OCI_OWNER=${{ github.repository_owner }}
 
     - name: Push CRDs chart to OCI registry
-      run: make crds-push-oci CHART_VERSION=${{ env.VERSION }} CHART_OCI_OWNER=${{ github.repository_owner }}
+      run: make crds-push-oci CHART_VERSION=${{ env.VERSION }} TAG=${{ env.VERSION }} CHART_OCI_OWNER=${{ github.repository_owner }}
 
 
     - name: Upload install.yaml artifact
@@ -122,7 +122,7 @@ jobs:
           ### If using Helm - Install CRDs first
           ```bash
           helm install kaiwo-crds oci://ghcr.io/${{ github.repository_owner }}/kaiwo-crds-chart \
-            --version ${{ env.VERSION }}
+            --version ${{ env.VERSION }} --namespace kaiwo-system --create-namespace
           ```
 
           ### Helm Install (from GitHub Releases)
@@ -136,6 +136,9 @@ jobs:
           helm install kaiwo oci://ghcr.io/${{ github.repository_owner }}/kaiwo-operator-chart \
             --version ${{ env.VERSION }} --namespace kaiwo-system --create-namespace
           ```
+
+          > NOTE: OCI chart paths moved from `oci://ghcr.io/${{ github.repository_owner }}/charts/*`
+          > to `oci://ghcr.io/${{ github.repository_owner }}/*`. Update automation using the old paths.
 
           ### Docker Images
           - Operator: `ghcr.io/${{ github.repository_owner }}/kaiwo-operator:${{ env.VERSION }}`

--- a/.github/workflows/compile-release.yaml
+++ b/.github/workflows/compile-release.yaml
@@ -55,12 +55,12 @@ jobs:
 
     - name: Generate install.yaml
       run: |
-        make build-installer TAG=${{ env.VERSION }}
+        make build-installer TAG=${{ env.VERSION }} IMG=ghcr.io/${{ github.repository_owner }}/kaiwo-operator:${{ env.VERSION }}
         cp dist/install.yaml install.yaml
 
     - name: Package Helm chart
       run: |
-        make helm-release TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }}
+        make helm-release TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }} IMG=ghcr.io/${{ github.repository_owner }}/kaiwo-operator:${{ env.VERSION }}
 
     - name: Compile CRDs to a single manifest
       run: |
@@ -75,10 +75,10 @@ jobs:
 
 
     - name: Push Helm chart to OCI registry
-      run: make helm-push-oci TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }}
+      run: make helm-push-oci TAG=${{ env.VERSION }} CHART_VERSION=${{ env.VERSION }} IMG=ghcr.io/${{ github.repository_owner }}/kaiwo-operator-chart:${{ env.VERSION }}
 
     - name: Push CRDs chart to OCI registry
-      run: make crds-push-oci CHART_VERSION=${{ env.VERSION }} CHART_OCI_OWNER=${{ github.repository_owner }}
+      run: make crds-push-oci CHART_VERSION=${{ env.VERSION }} IMG=ghcr.io/${{ github.repository_owner }}/kaiwo-operator-crds:${{ env.VERSION }}
 
 
     - name: Upload install.yaml artifact

--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -213,7 +213,13 @@ jobs:
 
     - name: Wait for rollout
       run: |
-        kubectl -n kaiwo-system rollout status deployment/kaiwo-controller-manager --timeout=300s
+        CONTROLLER_DEPLOYMENT=$(kubectl -n kaiwo-system get deployments -l app.kubernetes.io/name=kaiwo,control-plane=kaiwo-controller-manager -o jsonpath='{.items[0].metadata.name}')
+        if [ -z "$CONTROLLER_DEPLOYMENT" ]; then
+          echo "Could not find Kaiwo controller deployment in kaiwo-system"
+          kubectl -n kaiwo-system get deployments -o wide
+          exit 1
+        fi
+        kubectl -n kaiwo-system rollout status "deployment/$CONTROLLER_DEPLOYMENT" --timeout=300s
         kubectl -n kube-system rollout status deployment/kaiwo-scheduler --timeout=300s
         kubectl -n kaiwo-system get pods -o wide
 
@@ -229,15 +235,20 @@ jobs:
         kubectl -n kube-system get pods -o wide
 
         echo "=== Controller manager pod details ==="
-        kubectl -n kaiwo-system describe deployment kaiwo-controller-manager
-        kubectl -n kaiwo-system describe pods -l control-plane=controller-manager
+        CONTROLLER_DEPLOYMENT=$(kubectl -n kaiwo-system get deployments -l app.kubernetes.io/name=kaiwo,control-plane=kaiwo-controller-manager -o jsonpath='{.items[0].metadata.name}')
+        if [ -n "$CONTROLLER_DEPLOYMENT" ]; then
+          kubectl -n kaiwo-system describe "deployment/$CONTROLLER_DEPLOYMENT"
+        else
+          echo "Controller deployment not found via labels"
+        fi
+        kubectl -n kaiwo-system describe pods -l control-plane=kaiwo-controller-manager
 
         echo "=== Scheduler pod details ==="
         kubectl -n kube-system describe deployment kaiwo-scheduler
         kubectl -n kube-system describe pods -l component=kaiwo-scheduler
 
         echo "=== Controller manager logs ==="
-        kubectl -n kaiwo-system logs -l control-plane=controller-manager --tail=100 --all-containers=true || true
+        kubectl -n kaiwo-system logs -l control-plane=kaiwo-controller-manager --tail=100 --all-containers=true || true
 
         echo "=== Scheduler logs ==="
         kubectl -n kube-system logs -l component=kaiwo-scheduler --tail=100 --all-containers=true || true

--- a/.github/workflows/publish-main.yaml
+++ b/.github/workflows/publish-main.yaml
@@ -76,14 +76,14 @@ jobs:
 
       - name: Package Helm chart
         run: |
-          make helm-release TAG=${IMAGE_TAG} CHART_VERSION=${CHART_VERSION}
+          make helm-package TAG=${IMAGE_TAG} CHART_VERSION=${CHART_VERSION} IMG=${IMAGE_REPO}:${IMAGE_TAG}
 
       - name: Log in to GHCR (Helm/OCI)
         run: echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io -u $GITHUB_ACTOR --password-stdin
 
       - name: Push Helm chart to OCI registry
         run: |
-          make helm-push-oci TAG=${IMAGE_TAG} CHART_VERSION=${CHART_VERSION}
+          make helm-push-oci TAG=${IMAGE_TAG} CHART_VERSION=${CHART_VERSION} CHART_OCI_OWNER=${{ github.repository_owner }}
 
       - name: Commit and push to publish-main
         run: |

--- a/Makefile
+++ b/Makefile
@@ -6,12 +6,13 @@ IMG ?= ghcr.io/silogen/kaiwo-operator:${TAG}
 
 # Helm chart configuration
 CHART_DIR ?= chart
-CHART_NAME ?= kaiwo-operator
+CHART_NAME ?= kaiwo-operator-chart
+CRDS_CHART_NAME ?= kaiwo-crds-chart
 CHART_VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")
 APP_VERSION ?= ${TAG}
 CHART_OCI_REGISTRY ?= $(shell echo $(IMG) | cut -d'/' -f1)
 CHART_OCI_OWNER ?= $(shell echo $(IMG) | cut -d'/' -f2)
-CHART_OCI_REPO ?= oci://$(CHART_OCI_REGISTRY)/$(CHART_OCI_OWNER)/charts
+CHART_OCI_REPO ?= oci://$(CHART_OCI_REGISTRY)/$(CHART_OCI_OWNER)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))
@@ -172,6 +173,17 @@ helm-package: build-installer ## Package the Helm chart
 	helm package $(CHART_DIR) --version=$(CHART_VERSION) --app-version=$(APP_VERSION) --destination=dist/
 	@rm -f $(CHART_DIR)/Chart.yaml.bak
 
+.PHONY: crds-package
+crds-package: crds ## Package CRDs as a Helm chart .tgz for OCI distribution.
+	@echo "Packaging CRDs as Helm chart with version $(CHART_VERSION)..."
+	@rm -rf dist/crds-chart
+	@mkdir -p dist/crds-chart/templates
+	@printf 'apiVersion: v2\nname: %s\ndescription: CRDs for kaiwo operator\ntype: application\nversion: %s\nappVersion: "%s"\n' \
+		"$(CRDS_CHART_NAME)" "$(CHART_VERSION)" "$(APP_VERSION)" > dist/crds-chart/Chart.yaml
+	@cp crds.yaml dist/crds-chart/templates/crds.yaml
+	helm package dist/crds-chart --version=$(CHART_VERSION) --app-version=$(APP_VERSION) --destination=dist/
+	@echo "CRDs chart packaged at dist/$(CRDS_CHART_NAME)-$(CHART_VERSION).tgz"
+
 .PHONY: helm-install
 helm-install: helm-package ## Install the Helm chart locally
 	@echo "Installing Helm chart to kaiwo-system namespace..."
@@ -192,6 +204,12 @@ helm-template: build-installer ## Generate Helm templates for inspection
 helm-push-oci: helm-package ## Push Helm chart to OCI registry
 	@echo "Pushing Helm chart to OCI registry..."
 	helm push dist/$(CHART_NAME)-$(CHART_VERSION).tgz $(CHART_OCI_REPO)
+
+.PHONY: crds-push-oci
+crds-push-oci: ## Push CRDs Helm chart to OCI registry (requires crds-package first).
+	@echo "Pushing CRDs chart to OCI registry $(CHART_OCI_REPO)..."
+	helm push dist/$(CRDS_CHART_NAME)-$(CHART_VERSION).tgz $(CHART_OCI_REPO)
+
 
 .PHONY: helm-release
 helm-release: helm-package ## Package chart for release (used by CI)

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,15 @@ TAG ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "latest")
 IMG ?= ghcr.io/silogen/kaiwo-operator:${TAG}
 
 # Helm chart configuration
+# chart/Chart.yaml keeps the logical chart name (e.g. kaiwo-operator). HELM_OCI_CHART_NAME
+# is only for the packaged .tgz / OCI artifact (kaiwo-operator-chart), so CI can set
+# CHART_NAME=kaiwo-operator like the reference repo without breaking helm push paths.
 CHART_DIR ?= chart
-CHART_NAME ?= kaiwo-operator-chart
+HELM_OCI_CHART_NAME ?= kaiwo-operator-chart
 CRDS_CHART_NAME ?= kaiwo-crds-chart
 CHART_VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")
 APP_VERSION ?= ${TAG}
-# Keep Helm charts in a separate OCI path from container images to avoid
-# sharing the same ghcr.io/<owner>/<name> namespace.
-CHART_OCI_REGISTRY ?= $(shell echo $(IMG) | cut -d'/' -f1)
+CHART_OCI_REGISTRY ?= ghcr.io
 CHART_OCI_OWNER ?= $(shell echo $(IMG) | cut -d'/' -f2)
 CHART_OCI_REPO ?= oci://$(CHART_OCI_REGISTRY)/$(CHART_OCI_OWNER)
 
@@ -57,10 +58,6 @@ fmt: ## Run go fmt against code.
 .PHONY: vet
 vet: ## Run go vet against code.
 	go vet ./...
-
-.PHONY: test
-test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 TEST_NAME ?= "kaiwo-test"
 
@@ -107,7 +104,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./pkg/... -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
 
 .PHONY: docker-build
 docker-build: ## Build Docker image for the manager.
@@ -170,9 +167,12 @@ helm-package: build-installer ## Package the Helm chart
 	}
 	@echo "Packaging Helm chart with version $(CHART_VERSION) and app version $(APP_VERSION)"
 	$(call copy-helm-resources)
+	@cp $(CHART_DIR)/Chart.yaml $(CHART_DIR)/Chart.yaml.prepackage
+	@sed -i.bak 's/^name:.*/name: $(HELM_OCI_CHART_NAME)/' $(CHART_DIR)/Chart.yaml
 	@sed -i.bak 's/^version:.*/version: $(CHART_VERSION)/' $(CHART_DIR)/Chart.yaml
 	@sed -i.bak 's/^appVersion:.*/appVersion: "$(APP_VERSION)"/' $(CHART_DIR)/Chart.yaml
 	helm package $(CHART_DIR) --version=$(CHART_VERSION) --app-version=$(APP_VERSION) --destination=dist/
+	@mv $(CHART_DIR)/Chart.yaml.prepackage $(CHART_DIR)/Chart.yaml
 	@rm -f $(CHART_DIR)/Chart.yaml.bak
 
 .PHONY: crds
@@ -193,7 +193,7 @@ crds-package: crds ## Package CRDs as a Helm chart .tgz for OCI distribution.
 .PHONY: helm-install
 helm-install: helm-package ## Install the Helm chart locally
 	@echo "Installing Helm chart to kaiwo-system namespace..."
-	helm upgrade --install kaiwo dist/$(CHART_NAME)-$(CHART_VERSION).tgz --namespace kaiwo-system --create-namespace
+	helm upgrade --install kaiwo dist/$(HELM_OCI_CHART_NAME)-$(CHART_VERSION).tgz --namespace kaiwo-system --create-namespace
 
 .PHONY: helm-uninstall
 helm-uninstall: ## Uninstall the Helm chart
@@ -209,7 +209,7 @@ helm-template: build-installer ## Generate Helm templates for inspection
 .PHONY: helm-push-oci
 helm-push-oci: helm-package ## Push Helm chart to OCI registry
 	@echo "Pushing Helm chart to OCI registry..."
-	helm push dist/$(CHART_NAME)-$(CHART_VERSION).tgz $(CHART_OCI_REPO)
+	helm push dist/$(HELM_OCI_CHART_NAME)-$(CHART_VERSION).tgz $(CHART_OCI_REPO)
 
 .PHONY: crds-push-oci
 crds-push-oci: ## Push CRDs Helm chart to OCI registry (requires crds-package first).
@@ -219,7 +219,7 @@ crds-push-oci: ## Push CRDs Helm chart to OCI registry (requires crds-package fi
 
 .PHONY: helm-release
 helm-release: helm-package ## Package chart for release (used by CI)
-	@echo "Helm chart packaged for release: dist/$(CHART_NAME)-$(CHART_VERSION).tgz"
+	@echo "Helm chart packaged for release: dist/$(HELM_OCI_CHART_NAME)-$(CHART_VERSION).tgz"
 
 
 ##@ Deployment

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ run: manifests generate fmt vet ## Run a controller from your host.
 
 .PHONY: test
 test: manifests generate fmt vet setup-envtest ## Run tests.
-	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test $$(go list ./... | grep -v /e2e) -coverprofile cover.out
+	KUBEBUILDER_ASSETS="$(shell $(ENVTEST) use $(ENVTEST_K8S_VERSION) --bin-dir $(LOCALBIN) -p path)" go test ./pkg/... -coverprofile cover.out
 
 .PHONY: docker-build
 docker-build: ## Build Docker image for the manager.

--- a/Makefile
+++ b/Makefile
@@ -173,6 +173,10 @@ helm-package: build-installer ## Package the Helm chart
 	helm package $(CHART_DIR) --version=$(CHART_VERSION) --app-version=$(APP_VERSION) --destination=dist/
 	@rm -f $(CHART_DIR)/Chart.yaml.bak
 
+.PHONY: crds
+crds: kustomize ## Build consolidated CRD manifest to crds.yaml
+	$(KUSTOMIZE) build config/crd > crds.yaml
+
 .PHONY: crds-package
 crds-package: crds ## Package CRDs as a Helm chart .tgz for OCI distribution.
 	@echo "Packaging CRDs as Helm chart with version $(CHART_VERSION)..."

--- a/Makefile
+++ b/Makefile
@@ -6,13 +6,12 @@ IMG ?= ghcr.io/silogen/kaiwo-operator:${TAG}
 
 # Helm chart configuration
 CHART_DIR ?= chart
-CHART_NAME ?= kaiwo-operator
+CHART_NAME ?= kaiwo-operator-chart
 CRDS_CHART_NAME ?= kaiwo-crds-chart
 CHART_VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")
 APP_VERSION ?= ${TAG}
-# OCI Helm charts must not share the same ghcr.io repo path as the operator container
-# image (both would be owner/kaiwo-operator). Push charts under .../charts/; Helm then
-# stores e.g. oci://ghcr.io/ORG/charts → ghcr.io/ORG/charts/kaiwo-operator:<chartVer>.
+# Keep Helm charts in a separate OCI path from container images to avoid
+# sharing the same ghcr.io/<owner>/<name> namespace.
 CHART_OCI_REGISTRY ?= $(shell echo $(IMG) | cut -d'/' -f1)
 CHART_OCI_OWNER ?= $(shell echo $(IMG) | cut -d'/' -f2)
 CHART_OCI_REPO ?= oci://$(CHART_OCI_REGISTRY)/$(CHART_OCI_OWNER)

--- a/Makefile
+++ b/Makefile
@@ -6,10 +6,13 @@ IMG ?= ghcr.io/silogen/kaiwo-operator:${TAG}
 
 # Helm chart configuration
 CHART_DIR ?= chart
-CHART_NAME ?= kaiwo-operator-chart
+CHART_NAME ?= kaiwo-operator
 CRDS_CHART_NAME ?= kaiwo-crds-chart
 CHART_VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")
 APP_VERSION ?= ${TAG}
+# OCI Helm charts must not share the same ghcr.io repo path as the operator container
+# image (both would be owner/kaiwo-operator). Push charts under .../charts/; Helm then
+# stores e.g. oci://ghcr.io/ORG/charts → ghcr.io/ORG/charts/kaiwo-operator:<chartVer>.
 CHART_OCI_REGISTRY ?= $(shell echo $(IMG) | cut -d'/' -f1)
 CHART_OCI_OWNER ?= $(shell echo $(IMG) | cut -d'/' -f2)
 CHART_OCI_REPO ?= oci://$(CHART_OCI_REGISTRY)/$(CHART_OCI_OWNER)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 # Default tag from git
 TAG ?= $(shell git describe --tags --abbrev=0 2>/dev/null || echo "latest")
+GIT_ORG ?= $(shell git remote get-url origin 2>/dev/null | sed -n 's|.*github\.com[:/]\([^/]*\)/.*|\1|p')
 
 # Image URL to use for all building/pushing image targets
 IMG ?= ghcr.io/silogen/kaiwo-operator:${TAG}
@@ -14,7 +15,7 @@ CRDS_CHART_NAME ?= kaiwo-crds-chart
 CHART_VERSION ?= $(shell git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo "0.1.0")
 APP_VERSION ?= ${TAG}
 CHART_OCI_REGISTRY ?= ghcr.io
-CHART_OCI_OWNER ?= $(shell echo $(IMG) | cut -d'/' -f2)
+CHART_OCI_OWNER ?= $(if $(GIT_ORG),$(GIT_ORG),$(shell echo $(IMG) | cut -d'/' -f2))
 CHART_OCI_REPO ?= oci://$(CHART_OCI_REGISTRY)/$(CHART_OCI_OWNER)
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
@@ -167,16 +168,15 @@ helm-package: build-installer ## Package the Helm chart
 	}
 	@echo "Packaging Helm chart with version $(CHART_VERSION) and app version $(APP_VERSION)"
 	$(call copy-helm-resources)
-	@cp $(CHART_DIR)/Chart.yaml $(CHART_DIR)/Chart.yaml.prepackage
-	@sed -i.bak 's/^name:.*/name: $(HELM_OCI_CHART_NAME)/' $(CHART_DIR)/Chart.yaml
-	@sed -i.bak 's/^version:.*/version: $(CHART_VERSION)/' $(CHART_DIR)/Chart.yaml
-	@sed -i.bak 's/^appVersion:.*/appVersion: "$(APP_VERSION)"/' $(CHART_DIR)/Chart.yaml
-	helm package $(CHART_DIR) --version=$(CHART_VERSION) --app-version=$(APP_VERSION) --destination=dist/
-	@mv $(CHART_DIR)/Chart.yaml.prepackage $(CHART_DIR)/Chart.yaml
-	@rm -f $(CHART_DIR)/Chart.yaml.bak
+	@cp "$(CHART_DIR)/Chart.yaml" "$(CHART_DIR)/Chart.yaml.prepackage"
+	@trap 'if [ -f "$(CHART_DIR)/Chart.yaml.prepackage" ]; then mv "$(CHART_DIR)/Chart.yaml.prepackage" "$(CHART_DIR)/Chart.yaml"; fi; rm -f "$(CHART_DIR)/Chart.yaml.bak"' EXIT; \
+		sed -i.bak 's/^name:.*/name: $(HELM_OCI_CHART_NAME)/' "$(CHART_DIR)/Chart.yaml"; \
+		sed -i.bak 's/^version:.*/version: $(CHART_VERSION)/' "$(CHART_DIR)/Chart.yaml"; \
+		sed -i.bak 's/^appVersion:.*/appVersion: "$(APP_VERSION)"/' "$(CHART_DIR)/Chart.yaml"; \
+		helm package "$(CHART_DIR)" --version="$(CHART_VERSION)" --app-version="$(APP_VERSION)" --destination=dist/
 
 .PHONY: crds
-crds: kustomize ## Build consolidated CRD manifest to crds.yaml
+crds: manifests kustomize ## Build consolidated CRD manifest to crds.yaml
 	$(KUSTOMIZE) build config/crd > crds.yaml
 
 .PHONY: crds-package
@@ -207,12 +207,13 @@ helm-template: build-installer ## Generate Helm templates for inspection
 	@rm -f $(CHART_DIR)/Chart.yaml.bak
 
 .PHONY: helm-push-oci
-helm-push-oci: helm-package ## Push Helm chart to OCI registry
+helm-push-oci: ## Push Helm chart to OCI registry (requires helm-package first).
 	@echo "Pushing Helm chart to OCI registry..."
+	@test -f dist/$(HELM_OCI_CHART_NAME)-$(CHART_VERSION).tgz || { echo "Missing dist/$(HELM_OCI_CHART_NAME)-$(CHART_VERSION).tgz; run 'make helm-package CHART_VERSION=$(CHART_VERSION) TAG=$(TAG)' first."; exit 1; }
 	helm push dist/$(HELM_OCI_CHART_NAME)-$(CHART_VERSION).tgz $(CHART_OCI_REPO)
 
 .PHONY: crds-push-oci
-crds-push-oci: ## Push CRDs Helm chart to OCI registry (requires crds-package first).
+crds-push-oci: crds-package ## Push CRDs Helm chart to OCI registry.
 	@echo "Pushing CRDs chart to OCI registry $(CHART_OCI_REPO)..."
 	helm push dist/$(CRDS_CHART_NAME)-$(CHART_VERSION).tgz $(CHART_OCI_REPO)
 

--- a/docs/docs/admin/installation.md
+++ b/docs/docs/admin/installation.md
@@ -67,12 +67,16 @@ You can install Kaiwo via Helm (recommended) or by applying a prebuilt manifest 
 Install from the OCI registry:
 
 ```bash
+
+# Install Kaiwo CRDs
+helm install kaiwo oci://ghcr.io/silogen/kaiwo-operator-chart/kaiwo-crds-chart
+
 # Install latest version to kaiwo-system namespace
-helm install kaiwo oci://ghcr.io/silogen/charts/kaiwo-operator \
+helm install kaiwo oci://ghcr.io/silogen/kaiwo-operator-chart/kaiwo-operator-chart \
   --namespace kaiwo-system --create-namespace
 
 # Install a specific version
-helm install kaiwo oci://ghcr.io/silogen/charts/kaiwo-operator \
+helm install kaiwo oci://ghcr.io/silogen/kaiwo-operator-chart/kaiwo-operator \
   --version <version> \
   --namespace kaiwo-system --create-namespace
 ```

--- a/docs/docs/admin/installation.md
+++ b/docs/docs/admin/installation.md
@@ -68,7 +68,8 @@ Install from the OCI registry:
 
 ```bash
 # Install Kaiwo CRDs (OCI chart name: kaiwo-crds-chart)
-helm install kaiwo-crds oci://ghcr.io/silogen/kaiwo-crds-chart
+helm install kaiwo-crds oci://ghcr.io/silogen/kaiwo-crds-chart \
+  --namespace kaiwo-system --create-namespace
 
 # Install latest operator chart (OCI chart name: kaiwo-operator-chart; Chart.yaml name stays kaiwo-operator)
 helm install kaiwo oci://ghcr.io/silogen/kaiwo-operator-chart \
@@ -79,6 +80,9 @@ helm install kaiwo oci://ghcr.io/silogen/kaiwo-operator-chart \
   --version <version> \
   --namespace kaiwo-system --create-namespace
 ```
+
+> Note: OCI chart paths used to include `/charts/` (for example
+> `oci://ghcr.io/silogen/charts/kaiwo-operator`). Use the new paths above.
 
 #### Option B — Kustomize Manifests
 

--- a/docs/docs/admin/installation.md
+++ b/docs/docs/admin/installation.md
@@ -67,16 +67,15 @@ You can install Kaiwo via Helm (recommended) or by applying a prebuilt manifest 
 Install from the OCI registry:
 
 ```bash
+# Install Kaiwo CRDs (OCI chart name: kaiwo-crds-chart)
+helm install kaiwo-crds oci://ghcr.io/silogen/kaiwo-crds-chart
 
-# Install Kaiwo CRDs
-helm install kaiwo oci://ghcr.io/silogen/kaiwo-operator-chart/kaiwo-crds-chart
-
-# Install latest version to kaiwo-system namespace
-helm install kaiwo oci://ghcr.io/silogen/kaiwo-operator-chart/kaiwo-operator-chart \
+# Install latest operator chart (OCI chart name: kaiwo-operator-chart; Chart.yaml name stays kaiwo-operator)
+helm install kaiwo oci://ghcr.io/silogen/kaiwo-operator-chart \
   --namespace kaiwo-system --create-namespace
 
-# Install a specific version
-helm install kaiwo oci://ghcr.io/silogen/kaiwo-operator-chart/kaiwo-operator \
+# Install a specific chart version
+helm install kaiwo oci://ghcr.io/silogen/kaiwo-operator-chart \
   --version <version> \
   --namespace kaiwo-system --create-namespace
 ```

--- a/test/chainsaw/tests/standard/kaiwoqueueconfigs/ensure-no-overwrite/chainsaw-test.yaml
+++ b/test/chainsaw/tests/standard/kaiwoqueueconfigs/ensure-no-overwrite/chainsaw-test.yaml
@@ -37,16 +37,13 @@ spec:
           namespace: kaiwo-system
           labels:
             app.kubernetes.io/name: kaiwo
-    - wait:
-        apiVersion: apps/v1
-        kind: Deployment
-        name: kaiwo-controller-manager
-        namespace: kaiwo-system
-        timeout: 1m
-        for:
-          condition:
-            name: Available
-            value: 'true'
+    - script:
+        content: |
+          kubectl wait deployments.v1.apps \
+            -n kaiwo-system \
+            -l app.kubernetes.io/name=kaiwo,control-plane=kaiwo-controller-manager \
+            --for=condition=Available=true \
+            --timeout=1m
     - sleep:
         duration: 10s
     - assert:
@@ -67,16 +64,13 @@ spec:
           namespace: kaiwo-system
           labels:
             app.kubernetes.io/name: kaiwo
-    - wait:
-        apiVersion: apps/v1
-        kind: Deployment
-        name: kaiwo-controller-manager
-        namespace: kaiwo-system
-        timeout: 1m
-        for:
-          condition:
-            name: Available
-            value: 'true'
+    - script:
+        content: |
+          kubectl wait deployments.v1.apps \
+            -n kaiwo-system \
+            -l app.kubernetes.io/name=kaiwo,control-plane=kaiwo-controller-manager \
+            --for=condition=Available=true \
+            --timeout=1m
     - sleep:
         duration: 10s
     - assert:

--- a/test/chainsaw/tests/standard/kaiwoqueueconfigs/ensure-no-overwrite/chainsaw-test.yaml
+++ b/test/chainsaw/tests/standard/kaiwoqueueconfigs/ensure-no-overwrite/chainsaw-test.yaml
@@ -38,12 +38,13 @@ spec:
           labels:
             app.kubernetes.io/name: kaiwo
     - script:
+        timeout: 2m
         content: |
           kubectl wait deployments.v1.apps \
             -n kaiwo-system \
             -l app.kubernetes.io/name=kaiwo,control-plane=kaiwo-controller-manager \
             --for=condition=Available=true \
-            --timeout=1m
+            --timeout=2m
     - sleep:
         duration: 10s
     - assert:
@@ -65,12 +66,13 @@ spec:
           labels:
             app.kubernetes.io/name: kaiwo
     - script:
+        timeout: 2m
         content: |
           kubectl wait deployments.v1.apps \
             -n kaiwo-system \
             -l app.kubernetes.io/name=kaiwo,control-plane=kaiwo-controller-manager \
             --for=condition=Available=true \
-            --timeout=1m
+            --timeout=2m
     - sleep:
         duration: 10s
     - assert:

--- a/test/chainsaw/tests/standard/node-watching/chainsaw-test.yaml
+++ b/test/chainsaw/tests/standard/node-watching/chainsaw-test.yaml
@@ -6,6 +6,14 @@ spec:
   concurrent: false
   steps:
   - try:
+    - patch:
+        resource:
+          apiVersion: config.kaiwo.silogen.ai/v1alpha1
+          kind: KaiwoConfig
+          metadata:
+            name: kaiwo
+          spec:
+            dynamicallyUpdateDefaultClusterQueue: true
     - script:
         content: kubectl cordon kaiwo-test-worker
     - sleep:


### PR DESCRIPTION
# Description

The PR adds building CRD to OCI image during compile-release and also removes `charts/` directory from ghcr path as requested by the platform team. 
