### PR TITLE
feat: Add scheduler scoringStrategy Helm value for GPU spread

### DIFF
--- a/chart/templates/scheduler.yaml
+++ b/chart/templates/scheduler.yaml
@@ -4,7 +4,11 @@ Kaiwo Scheduler resources
 {{- if .Values.scheduler.enabled }}
 # Generated from config/static/scheduler
 {{- $sched := (.Files.Get "scheduler-resources.yaml") | replace "namespace: kube-system" (printf "namespace: %s" .Values.scheduler.namespace) }}
-{{- if eq .Values.scheduler.scoringStrategy "LeastAllocated" }}
+{{- $strategy := .Values.scheduler.scoringStrategy }}
+{{- if not (or (eq $strategy "RequestedToCapacityRatio") (eq $strategy "LeastAllocated")) }}
+{{- fail (printf "scheduler.scoringStrategy must be RequestedToCapacityRatio or LeastAllocated, got %q" $strategy) }}
+{{- end }}
+{{- if eq $strategy "LeastAllocated" }}
 {{- $binpack := `RequestedToCapacityRatio
                 resources:
                   - name: nvidia.com/gpu

--- a/chart/templates/scheduler.yaml
+++ b/chart/templates/scheduler.yaml
@@ -3,5 +3,27 @@ Kaiwo Scheduler resources
 */}}
 {{- if .Values.scheduler.enabled }}
 # Generated from config/static/scheduler
-{{ (.Files.Get "scheduler-resources.yaml") | replace "namespace: kube-system" (printf "namespace: %s" .Values.scheduler.namespace) }}
+{{- $sched := (.Files.Get "scheduler-resources.yaml") | replace "namespace: kube-system" (printf "namespace: %s" .Values.scheduler.namespace) }}
+{{- if eq .Values.scheduler.scoringStrategy "LeastAllocated" }}
+{{- $binpack := `RequestedToCapacityRatio
+                resources:
+                  - name: nvidia.com/gpu
+                    weight: 5
+                  - name: amd.com/gpu
+                    weight: 5
+                requestedToCapacityRatio:
+                  shape:
+                    - utilization: 0
+                      score: 0
+                    - utilization: 100
+                      score: 10` }}
+{{- $spread := `LeastAllocated
+                resources:
+                  - name: nvidia.com/gpu
+                    weight: 5
+                  - name: amd.com/gpu
+                    weight: 5` }}
+{{- $sched = $sched | replace $binpack $spread }}
+{{- end }}
+{{ $sched }}
 {{- end }}

--- a/chart/values.yaml
+++ b/chart/values.yaml
@@ -59,6 +59,10 @@ scheduler:
   enabled: true
   # Namespace where scheduler will be deployed (typically kube-system)
   namespace: kube-system
+  # GPU scoring strategy for the NodeResourcesFit plugin:
+  #   RequestedToCapacityRatio - bin-pack, packs workloads onto fewest nodes (default)
+  #   LeastAllocated           - spread, distributes workloads across nodes
+  scoringStrategy: RequestedToCapacityRatio
 
 # Security settings
 security:


### PR DESCRIPTION
## Summary
- Expose `scheduler.scoringStrategy` in the operator chart values so the `NodeResourcesFit` GPU scoring can switch between bin-pack and spread without a code change.
- Default is `RequestedToCapacityRatio` (bin-pack), which reproduces current behavior exactly. Set to `LeastAllocated` to spread GPU workloads across nodes.
- `config/static/scheduler/*` is left untouched (non-Helm default stays bin-pack).

## Why
For the AMD Advancing AI demo on MI350X nodes we want GPU workloads spread across nodes rather than bin-packed next to each other (heat/locality). This adds a values toggle so deployments (e.g. via GitOps values override) can pick the spread strategy without waiting on a code change.

## Implementation
`chart/templates/scheduler.yaml` includes the raw `scheduler-resources.yaml` ConfigMap via `.Files.Get`. When `scheduler.scoringStrategy=LeastAllocated`, the template rewrites the `RequestedToCapacityRatio` block to `LeastAllocated` (same GPU resource weights). Uses backtick raw strings for readability.

## Test plan
- [x] `helm template .` renders bin-pack by default (identical to current main)
- [x] `helm template . --set scheduler.scoringStrategy=LeastAllocated` renders `type: LeastAllocated`
- [x] Full chart render valid in both modes
- [x] Deploy to a cluster and confirm `kaiwo-scheduler-config` ConfigMap reflects the selected strategy (kube-scheduler needs a rollout restart, no hot-reload)

Note: this is node-level spread only. Intra-node GPU/PCIe placement is out of scope (would need the DRA driver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)